### PR TITLE
Add class-specific quest flow and rewards

### DIFF
--- a/ReplicatedStorage/GameConfig.lua
+++ b/ReplicatedStorage/GameConfig.lua
@@ -10,6 +10,35 @@ GameConfig.DefaultStats = {
     attack = 10,
     defense = 5,
     gold = 0,
+    class = "guerreiro",
+}
+
+GameConfig.Classes = {
+    default = "guerreiro",
+    guerreiro = {
+        name = "Guerreiro",
+        role = "Tank/Dano corpo a corpo",
+        strengths = {
+            "Alta resistência física",
+            "Capaz de proteger aliados em combate próximo",
+        },
+    },
+    arqueiro = {
+        name = "Arqueiro",
+        role = "Dano à distância",
+        strengths = {
+            "Rastreia alvos e explora o terreno",
+            "Especialista em acertar pontos fracos de inimigos distantes",
+        },
+    },
+    mago = {
+        name = "Mago",
+        role = "Suporte/Dano mágico",
+        strengths = {
+            "Manipula feitiços de área",
+            "Fornece suporte e proteção mágica ao grupo",
+        },
+    },
 }
 
 GameConfig.Experience = {

--- a/ReplicatedStorage/ItemsConfig.lua
+++ b/ReplicatedStorage/ItemsConfig.lua
@@ -37,6 +37,369 @@ local ItemsConfig = {
             experience = 50,
         },
     },
+    training_blade = {
+        id = "training_blade",
+        name = "Lâmina de Treinamento",
+        type = "equipment",
+        slot = "weapon",
+        description = "Uma espada leve usada para ensinar fundamentos aos guerreiros.",
+        attributes = {
+            attack = 5,
+        },
+    },
+    training_quiver = {
+        id = "training_quiver",
+        name = "Aljava de Treinamento",
+        type = "material",
+        description = "Conjunto de flechas simples para praticar mira e postura.",
+    },
+    training_grimoire = {
+        id = "training_grimoire",
+        name = "Grimório do Noviço",
+        type = "consumable",
+        description = "Um tomo com feitiços básicos que aumenta o domínio arcano.",
+        effects = {
+            experience = 25,
+        },
+    },
+    light_shield = {
+        id = "light_shield",
+        name = "Escudo Leve",
+        type = "equipment",
+        slot = "offhand",
+        description = "Escudo prático utilizado para proteger carregamentos pesados.",
+        attributes = {
+            defense = 4,
+        },
+    },
+    hunters_arrows = {
+        id = "hunters_arrows",
+        name = "Flechas do Caçador",
+        type = "material",
+        description = "Flechas reforçadas ideais para espantar aves e pequenas criaturas.",
+    },
+    growth_components = {
+        id = "growth_components",
+        name = "Componentes de Crescimento",
+        type = "material",
+        description = "Ingredientes mágicos capazes de acelerar o crescimento das plantas.",
+    },
+    guardian_blade = {
+        id = "guardian_blade",
+        name = "Lâmina do Guardião",
+        type = "equipment",
+        slot = "weapon",
+        description = "Uma espada equilibrada concedida a quem protege segredos antigos.",
+        attributes = {
+            attack = 8,
+        },
+    },
+    trail_lantern = {
+        id = "trail_lantern",
+        name = "Lanterna de Rastreamento",
+        type = "equipment",
+        slot = "trinket",
+        description = "Lanterna encantada que destaca rastros escondidos na mata.",
+        attributes = {
+            defense = 1,
+        },
+    },
+    rune_focus = {
+        id = "rune_focus",
+        name = "Foco Rúnico",
+        type = "equipment",
+        slot = "trinket",
+        description = "Um foco arcano que amplia a estabilidade das magias.",
+        attributes = {
+            maxMana = 10,
+        },
+    },
+    molten_gauntlets = {
+        id = "molten_gauntlets",
+        name = "Manoplas Derretidas",
+        type = "equipment",
+        slot = "hands",
+        description = "Manoplas forjadas para resistir ao calor extremo do vulcão.",
+        attributes = {
+            defense = 6,
+        },
+    },
+    ember_arrow_bundle = {
+        id = "ember_arrow_bundle",
+        name = "Feixe de Flechas Incandescentes",
+        type = "material",
+        description = "Flechas tratadas para perfurar criaturas adaptadas ao fogo.",
+    },
+    stability_charm = {
+        id = "stability_charm",
+        name = "Amuleto de Estabilidade",
+        type = "equipment",
+        slot = "accessory",
+        description = "Amuleto usado para manter cristais instáveis sob controle.",
+        attributes = {
+            defense = 4,
+        },
+    },
+    arena_plate = {
+        id = "arena_plate",
+        name = "Armadura da Arena",
+        type = "equipment",
+        slot = "armor",
+        description = "Armadura pesada concedida aos campeões da arena.",
+        attributes = {
+            defense = 12,
+        },
+    },
+    precision_string = {
+        id = "precision_string",
+        name = "Cordas de Precisão",
+        type = "material",
+        description = "Cordas de arco calibradas para disparos rápidos e precisos.",
+    },
+    dueling_tome = {
+        id = "dueling_tome",
+        name = "Tomo de Duelo",
+        type = "consumable",
+        description = "Registro de feitiços usado pelos duelistas da arena.",
+        effects = {
+            experience = 80,
+        },
+    },
+    foragers_belt = {
+        id = "foragers_belt",
+        name = "Cinto do Coletor",
+        type = "equipment",
+        slot = "belt",
+        description = "Cinto reforçado que ajuda a transportar ingredientes raros.",
+        attributes = {
+            defense = 3,
+        },
+    },
+    tracker_calls = {
+        id = "tracker_calls",
+        name = "Apito do Rastreador",
+        type = "material",
+        description = "Apito que atrai criaturas raras encontradas pelo arqueiro.",
+    },
+    alchemical_gloves = {
+        id = "alchemical_gloves",
+        name = "Luvas Alquímicas",
+        type = "equipment",
+        slot = "hands",
+        description = "Luvas encantadas que protegem o usuário durante misturas complexas.",
+        attributes = {
+            maxMana = 10,
+        },
+    },
+    interrogation_badge = {
+        id = "interrogation_badge",
+        name = "Distintivo de Interrogador",
+        type = "equipment",
+        slot = "accessory",
+        description = "Símbolo de autoridade usado para conduzir interrogatórios no castelo.",
+        attributes = {
+            defense = 3,
+        },
+    },
+    shadow_boots = {
+        id = "shadow_boots",
+        name = "Botas das Sombras",
+        type = "equipment",
+        slot = "boots",
+        description = "Botas leves que silenciam passos durante perseguições.",
+        attributes = {
+            defense = 4,
+        },
+    },
+    divination_orb = {
+        id = "divination_orb",
+        name = "Orbe de Adivinhação",
+        type = "equipment",
+        slot = "trinket",
+        description = "Orbe que auxilia magos a detectar resquícios mágicos.",
+        attributes = {
+            maxMana = 15,
+        },
+    },
+    warding_hammer = {
+        id = "warding_hammer",
+        name = "Martelo Guardião",
+        type = "equipment",
+        slot = "weapon",
+        description = "Martelo pesado capaz de destruir totens amaldiçoados.",
+        attributes = {
+            attack = 12,
+        },
+    },
+    purging_arrows = {
+        id = "purging_arrows",
+        name = "Flechas Purificantes",
+        type = "material",
+        description = "Flechas imbuidas de magia para purificar criaturas corrompidas.",
+    },
+    blooming_staff = {
+        id = "blooming_staff",
+        name = "Cajado Florescente",
+        type = "equipment",
+        slot = "weapon",
+        description = "Cajado que canaliza energia vital para restaurar a floresta.",
+        attributes = {
+            attack = 6,
+            maxMana = 10,
+        },
+    },
+    skybreaker_plate = {
+        id = "skybreaker_plate",
+        name = "Couraça Quebra-Céus",
+        type = "equipment",
+        slot = "armor",
+        description = "Armadura projetada para suportar pressões das alturas.",
+        attributes = {
+            defense = 14,
+        },
+    },
+    mechanism_kit = {
+        id = "mechanism_kit",
+        name = "Kit de Mecanismos",
+        type = "material",
+        description = "Ferramentas precisas usadas para ativar mecanismos suspensos.",
+    },
+    celestial_codex = {
+        id = "celestial_codex",
+        name = "Códice Celestial",
+        type = "consumable",
+        description = "Um tomo estrelado que amplia a reserva de mana ao ser estudado.",
+        effects = {
+            mana = 50,
+        },
+    },
+    dragonscale_shield = {
+        id = "dragonscale_shield",
+        name = "Escudo de Escama de Dragão",
+        type = "equipment",
+        slot = "offhand",
+        description = "Escudo imponente forjado com escamas do dragão sombrio.",
+        attributes = {
+            defense = 18,
+        },
+    },
+    dragonbane_arrows = {
+        id = "dragonbane_arrows",
+        name = "Flechas Mata-Dragão",
+        type = "material",
+        description = "Flechas projetadas para perfurar a blindagem das criaturas dracônicas.",
+    },
+    protective_barrier_scroll = {
+        id = "protective_barrier_scroll",
+        name = "Pergaminho de Barreira Protetora",
+        type = "consumable",
+        description = "Pergaminho que ensina a erguer barreiras mágicas poderosas.",
+        effects = {
+            mana = 35,
+        },
+    },
+    gatekeeper_halberd = {
+        id = "gatekeeper_halberd",
+        name = "Alabarda do Guardião",
+        type = "equipment",
+        slot = "weapon",
+        description = "Arma usada pelos guardas responsáveis por proteger os portões da cidade.",
+        attributes = {
+            attack = 16,
+        },
+    },
+    volley_quiver = {
+        id = "volley_quiver",
+        name = "Aljava de Rajada",
+        type = "material",
+        description = "Aljava preparada para disparar múltiplas flechas em sequência.",
+    },
+    stormcall_focus = {
+        id = "stormcall_focus",
+        name = "Foco Chamado da Tempestade",
+        type = "equipment",
+        slot = "trinket",
+        description = "Artefato que auxilia magos a canalizar energia explosiva em campo.",
+        attributes = {
+            maxMana = 20,
+        },
+    },
+    legendary_blade = {
+        id = "legendary_blade",
+        name = "Espada Lendária",
+        type = "equipment",
+        slot = "weapon",
+        description = "A lendária lâmina destinada ao golpe final contra o tirano.",
+        attributes = {
+            attack = 22,
+        },
+    },
+    forja_compass = {
+        id = "forja_compass",
+        name = "Bússola da Forja",
+        type = "material",
+        description = "Bússola encantada que aponta para a forja perdida.",
+    },
+    ritual_catalyst = {
+        id = "ritual_catalyst",
+        name = "Catalisador Ritualístico",
+        type = "consumable",
+        description = "Concentrado mágico utilizado para rituais complexos.",
+        effects = {
+            experience = 120,
+        },
+    },
+    royal_guard_plate = {
+        id = "royal_guard_plate",
+        name = "Armadura do Guardião Real",
+        type = "equipment",
+        slot = "armor",
+        description = "Armadura resistente concedida a quem defende o trono restaurado.",
+        attributes = {
+            defense = 20,
+        },
+    },
+    royal_arrowheads = {
+        id = "royal_arrowheads",
+        name = "Pontas Reais",
+        type = "material",
+        description = "Pontas de flecha forjadas com precisão para acertar pontos críticos.",
+    },
+    crown_sigil_cloak = {
+        id = "crown_sigil_cloak",
+        name = "Manto do Selo Real",
+        type = "equipment",
+        slot = "cloak",
+        description = "Manto cerimonial que amplia a proteção mágica do portador.",
+        attributes = {
+            defense = 5,
+            maxMana = 25,
+        },
+    },
+    maca_vermelha = {
+        id = "maca_vermelha",
+        name = "Maçã Vermelha",
+        type = "material",
+        description = "Fruta fresca colhida para o fazendeiro da vila.",
+    },
+    fragmento_mapa_central = {
+        id = "fragmento_mapa_central",
+        name = "Fragmento de Mapa Central",
+        type = "material",
+        description = "Uma das peças do mapa antigo que revela o caminho adiante.",
+    },
+    cristal_vulcanico = {
+        id = "cristal_vulcanico",
+        name = "Cristal Vulcânico",
+        type = "material",
+        description = "Cristal raro coletado nas profundezas do vulcão.",
+    },
+    essencia_alquimica = {
+        id = "essencia_alquimica",
+        name = "Essência Alquímica",
+        type = "material",
+        description = "Componentes raros necessários para misturar poções poderosas.",
+    },
 }
 
 return ItemsConfig

--- a/ReplicatedStorage/QuestConfig.lua
+++ b/ReplicatedStorage/QuestConfig.lua
@@ -32,5 +32,35 @@ local QuestConfig = {
     },
 }
 
+local function loadQuestModule(moduleScript)
+    local success, questDefinition = pcall(require, moduleScript)
+    if not success then
+        warn(string.format("Falha ao carregar missão %s: %s", moduleScript:GetFullName(), questDefinition))
+        return
+    end
+
+    if type(questDefinition) ~= "table" or not questDefinition.id then
+        warn(string.format("Módulo de missão inválido em %s", moduleScript:GetFullName()))
+        return
+    end
+
+    QuestConfig[questDefinition.id] = questDefinition
+end
+
+local function loadQuestFolder(container)
+    for _, child in ipairs(container:GetChildren()) do
+        if child:IsA("ModuleScript") then
+            loadQuestModule(child)
+        elseif child:IsA("Folder") then
+            loadQuestFolder(child)
+        end
+    end
+end
+
+local questsFolder = script.Parent:FindFirstChild("quests")
+if questsFolder then
+    loadQuestFolder(questsFolder)
+end
+
 return QuestConfig
 

--- a/ReplicatedStorage/quests/act1/colheita_simples.lua
+++ b/ReplicatedStorage/quests/act1/colheita_simples.lua
@@ -1,0 +1,58 @@
+local quest = {
+    id = "colheita_simples",
+    act = 1,
+    questType = "side",
+    name = "Colheita Simples",
+    description = "O fazendeiro local precisa de ajuda para garantir que as maçãs sejam entregues em segurança.",
+    objective = {
+        type = "collect",
+        target = "maca_vermelha",
+        count = 10,
+        description = "Colete 10 maçãs frescas para o fazendeiro.",
+        classObjectives = {
+            guerreiro = {
+                title = "Braços Fortes",
+                description = "Carregue sacos pesados de maçãs até o celeiro sem deixá-los cair.",
+            },
+            arqueiro = {
+                title = "Limpando os Céus",
+                description = "Cace as aves que roubam frutas antes que estraguem a colheita.",
+            },
+            mago = {
+                title = "Magia de Crescimento",
+                description = "Lance um feitiço que acelera o crescimento das macieiras para repor a produção.",
+            },
+        },
+        universal = {
+            title = "Maçãs para o Fazendeiro",
+            description = "Independentemente do método, entregue 10 maçãs saudáveis ao fazendeiro.",
+        },
+    },
+    reward = {
+        experience = 45,
+        gold = 20,
+        items = {
+            potion_small = 1,
+        },
+        classRewards = {
+            guerreiro = {
+                items = {
+                    light_shield = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    hunters_arrows = 1,
+                },
+            },
+            mago = {
+                items = {
+                    growth_components = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act1/mapa_fragmentado.lua
+++ b/ReplicatedStorage/quests/act1/mapa_fragmentado.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "mapa_fragmentado",
+    act = 1,
+    questType = "main",
+    name = "Mapa Fragmentado",
+    description = "Rumores indicam que um mapa antigo foi dividido entre diferentes guardiões. Reúna as peças para revelar o caminho adiante.",
+    objective = {
+        type = "collect",
+        target = "fragmento_mapa_central",
+        count = 1,
+        description = "Recupere a peça do mapa perdida e una-a às demais partes.",
+        classObjectives = {
+            guerreiro = {
+                title = "Guardião do Fragmento",
+                description = "Derrote o inimigo que vigia a peça do mapa em combate direto.",
+            },
+            arqueiro = {
+                title = "Rastros na Floresta",
+                description = "Siga pegadas até localizar um baú escondido contendo o fragmento.",
+            },
+            mago = {
+                title = "Enigma Arcano",
+                description = "Resolva um quebra-cabeça mágico para libertar o fragmento do selo.",
+            },
+        },
+        universal = {
+            title = "Fragmento Recuperado",
+            description = "Qualquer abordagem leva à mesma meta: recuperar a peça do mapa.",
+        },
+    },
+    reward = {
+        experience = 80,
+        gold = 40,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    guardian_blade = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    trail_lantern = 1,
+                },
+            },
+            mago = {
+                items = {
+                    rune_focus = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act1/primeira_caca.lua
+++ b/ReplicatedStorage/quests/act1/primeira_caca.lua
@@ -1,0 +1,58 @@
+local quest = {
+    id = "primeira_caca",
+    act = 1,
+    questType = "main",
+    name = "Primeira Caça",
+    description = "Os habitantes da vila precisam de ajuda para conter os slimes que surgem perto das plantações.",
+    objective = {
+        type = "kill",
+        target = "Slime",
+        count = 3,
+        description = "Derrote 3 slimes para demonstrar sua habilidade inicial de combate.",
+        classObjectives = {
+            guerreiro = {
+                title = "Investida Protetora",
+                description = "Enfrente 3 slimes em combate corpo a corpo para praticar bloqueios e contra-ataques.",
+            },
+            arqueiro = {
+                title = "Olhos no Alvo",
+                description = "Acerte 3 slimes à distância utilizando o arco para manter a linha segura.",
+            },
+            mago = {
+                title = "Explosão Arcanista",
+                description = "Use um feitiço de área para eliminar múltiplos slimes pequenos de uma só vez.",
+            },
+        },
+        universal = {
+            title = "Eliminar Slimes",
+            description = "Qualquer método conta para derrotar 3 slimes e proteger as colheitas.",
+        },
+    },
+    reward = {
+        experience = 60,
+        gold = 25,
+        items = {
+            potion_small = 1,
+        },
+        classRewards = {
+            guerreiro = {
+                items = {
+                    training_blade = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    training_quiver = 1,
+                },
+            },
+            mago = {
+                items = {
+                    training_grimoire = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act2/alquimista_perdido.lua
+++ b/ReplicatedStorage/quests/act2/alquimista_perdido.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "alquimista_perdido",
+    act = 2,
+    questType = "side",
+    name = "O Alquimista Perdido",
+    description = "Um alquimista desapareceu na mata coletando ingredientes raros. Reúna o que ele precisa para retornar ao trabalho.",
+    objective = {
+        type = "collect",
+        target = "essencia_alquimica",
+        count = 3,
+        description = "Junte ingredientes raros para preparar a poção do alquimista.",
+        classObjectives = {
+            guerreiro = {
+                title = "Proteção à Procura",
+                description = "Colete ervas em áreas perigosas afastando monstros do alquimista.",
+            },
+            arqueiro = {
+                title = "Caça Precisa",
+                description = "Cace criaturas raras para obter glândulas e penas especiais.",
+            },
+            mago = {
+                title = "Mistura Perfeita",
+                description = "Misture os ingredientes no caldeirão mágico garantindo a proporção correta.",
+            },
+        },
+        universal = {
+            title = "Poção Reconstruída",
+            description = "Independentemente das tarefas, entregue ao alquimista os componentes da poção.",
+        },
+    },
+    reward = {
+        experience = 120,
+        gold = 65,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    foragers_belt = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    tracker_calls = 1,
+                },
+            },
+            mago = {
+                items = {
+                    alchemical_gloves = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act2/arena_campeoes.lua
+++ b/ReplicatedStorage/quests/act2/arena_campeoes.lua
@@ -1,0 +1,58 @@
+local quest = {
+    id = "arena_campeoes",
+    act = 2,
+    questType = "main",
+    name = "A Arena dos Campeões",
+    description = "Prove sua força na arena enfrentando desafios alinhados à sua especialidade.",
+    objective = {
+        type = "story",
+        target = "titulo_campeao",
+        count = 1,
+        description = "Conquiste o direito de ser chamado de Campeão da Arena.",
+        classObjectives = {
+            guerreiro = {
+                title = "Confrontos Titânicos",
+                description = "Vença batalhas corpo a corpo contra campeões fortemente armados.",
+            },
+            arqueiro = {
+                title = "Precisão Impecável",
+                description = "Supere desafios de tiro ao alvo com tempo limitado.",
+            },
+            mago = {
+                title = "Duelo Arcano",
+                description = "Triunfe em duelos mágicos contra conjuradores da arena.",
+            },
+        },
+        universal = {
+            title = "Vença a Arena",
+            description = "Independente do estilo, vença os desafios para obter o título de campeão.",
+        },
+    },
+    reward = {
+        experience = 180,
+        gold = 90,
+        items = {
+            potion_small = 2,
+        },
+        classRewards = {
+            guerreiro = {
+                items = {
+                    arena_plate = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    precision_string = 1,
+                },
+            },
+            mago = {
+                items = {
+                    dueling_tome = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act2/expedicao_vulcao.lua
+++ b/ReplicatedStorage/quests/act2/expedicao_vulcao.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "expedicao_vulcao",
+    act = 2,
+    questType = "main",
+    name = "Expedição ao Vulcão",
+    description = "Os cristais do vulcão são vitais para estabilizar a energia do reino. Ajude a recuperá-los com segurança.",
+    objective = {
+        type = "collect",
+        target = "cristal_vulcanico",
+        count = 3,
+        description = "Recupere cristais vulcânicos intactos das profundezas da cratera.",
+        classObjectives = {
+            guerreiro = {
+                title = "Carga Resistente",
+                description = "Carregue cristais pesados pela lava enquanto protege os aliados.",
+            },
+            arqueiro = {
+                title = "Guarda Aérea",
+                description = "Elimine morcegos vulcânicos que atacam à distância durante a expedição.",
+            },
+            mago = {
+                title = "Estabilização Arcana",
+                description = "Use feitiços para estabilizar cristais instáveis e impedir explosões.",
+            },
+        },
+        universal = {
+            title = "Cristais Recuperados",
+            description = "Todas as tarefas convergem para recuperar cristais vulcânicos seguros.",
+        },
+    },
+    reward = {
+        experience = 150,
+        gold = 70,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    molten_gauntlets = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    ember_arrow_bundle = 1,
+                },
+            },
+            mago = {
+                items = {
+                    stability_charm = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act3/assassinato_castelo.lua
+++ b/ReplicatedStorage/quests/act3/assassinato_castelo.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "assassinato_castelo",
+    act = 3,
+    questType = "main",
+    name = "O Assassinato no Castelo",
+    description = "Um crime abalou o castelo e a verdade precisa ser descoberta antes que o reino mergulhe no caos.",
+    objective = {
+        type = "story",
+        target = "culpado_identificado",
+        count = 1,
+        description = "Reúna provas suficientes para identificar o assassino.",
+        classObjectives = {
+            guerreiro = {
+                title = "Linha de Interrogatório",
+                description = "Interrogue guardas suspeitos e confronte inconsistências.",
+            },
+            arqueiro = {
+                title = "Caça às Pistas",
+                description = "Siga pegadas e rastros sutis deixados pelo culpado.",
+            },
+            mago = {
+                title = "Resíduo Arcano",
+                description = "Analise resquícios mágicos presentes na cena do crime.",
+            },
+        },
+        universal = {
+            title = "Verdade Revelada",
+            description = "Combine as pistas para acusar corretamente o responsável.",
+        },
+    },
+    reward = {
+        experience = 210,
+        gold = 100,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    interrogation_badge = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    shadow_boots = 1,
+                },
+            },
+            mago = {
+                items = {
+                    divination_orb = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act3/maldicao_floresta.lua
+++ b/ReplicatedStorage/quests/act3/maldicao_floresta.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "maldicao_floresta",
+    act = 3,
+    questType = "main",
+    name = "A Maldição da Floresta",
+    description = "Uma maldição tomou conta da floresta ancestral. Purifique a área antes que corrompa o reino inteiro.",
+    objective = {
+        type = "story",
+        target = "floresta_purificada",
+        count = 1,
+        description = "Remova a maldição que assombra a floresta.",
+        classObjectives = {
+            guerreiro = {
+                title = "Quebra de Totens",
+                description = "Destrua totens corrompidos protegidos por espíritos malignos.",
+            },
+            arqueiro = {
+                title = "Caçada Purificadora",
+                description = "Cace criaturas amaldiçoadas antes que espalhem a corrupção.",
+            },
+            mago = {
+                title = "Ritual de Quebra",
+                description = "Execute um ritual para dissipar a magia sombria que domina a floresta.",
+            },
+        },
+        universal = {
+            title = "Floresta Restaurada",
+            description = "Conclua os passos necessários para purificar a floresta.",
+        },
+    },
+    reward = {
+        experience = 230,
+        gold = 110,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    warding_hammer = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    purging_arrows = 1,
+                },
+            },
+            mago = {
+                items = {
+                    blooming_staff = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act4/cacada_dragao_sombrio.lua
+++ b/ReplicatedStorage/quests/act4/cacada_dragao_sombrio.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "cacada_dragao_sombrio",
+    act = 4,
+    questType = "main",
+    name = "A Caçada ao Dragão Sombrio",
+    description = "O dragão sombrio ameaça destruir o reino. Coordene-se com seus aliados para pôr fim à criatura.",
+    objective = {
+        type = "kill",
+        target = "DragaoSombrio",
+        count = 1,
+        description = "Derrote o dragão sombrio para salvar o reino.",
+        classObjectives = {
+            guerreiro = {
+                title = "Escudo da Linha de Frente",
+                description = "Enfrente o dragão corpo a corpo e mantenha sua atenção no tanque.",
+            },
+            arqueiro = {
+                title = "Pontaria Cirúrgica",
+                description = "Acerte os pontos fracos nas asas e na cauda para limitar os movimentos do dragão.",
+            },
+            mago = {
+                title = "Suporte Arcano",
+                description = "Proteja os aliados com escudos mágicos e conjure feitiços de área.",
+            },
+        },
+        universal = {
+            title = "Dragão Abatido",
+            description = "Independentemente das funções individuais, o objetivo final é derrubar o dragão.",
+        },
+    },
+    reward = {
+        experience = 330,
+        gold = 180,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    dragonscale_shield = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    dragonbane_arrows = 1,
+                },
+            },
+            mago = {
+                items = {
+                    protective_barrier_scroll = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act4/invasao_orc.lua
+++ b/ReplicatedStorage/quests/act4/invasao_orc.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "invasao_orc",
+    act = 4,
+    questType = "side",
+    name = "Invasão Orc",
+    description = "Os orcs iniciaram uma ofensiva contra a cidade. Coordene a defesa para repelir a invasão.",
+    objective = {
+        type = "kill",
+        target = "OrcInvasor",
+        count = 15,
+        description = "Derrote os orcs invasores e proteja os cidadãos.",
+        classObjectives = {
+            guerreiro = {
+                title = "Guardiões dos Portões",
+                description = "Proteja os portões da cidade contra a aríete orc.",
+            },
+            arqueiro = {
+                title = "Tiro nas Torres",
+                description = "Elimine arqueiros orcs posicionados nas torres distantes.",
+            },
+            mago = {
+                title = "Suporte Explosivo",
+                description = "Use feitiços de cura e explosão para conter grandes grupos de inimigos.",
+            },
+        },
+        universal = {
+            title = "Invasão Rechaçada",
+            description = "Una os esforços para repelir a invasão orc e garantir a segurança da cidade.",
+        },
+    },
+    reward = {
+        experience = 250,
+        gold = 120,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    gatekeeper_halberd = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    volley_quiver = 1,
+                },
+            },
+            mago = {
+                items = {
+                    stormcall_focus = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act4/torre_ceus.lua
+++ b/ReplicatedStorage/quests/act4/torre_ceus.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "torre_ceus",
+    act = 4,
+    questType = "main",
+    name = "A Torre dos Céus",
+    description = "A torre flutuante guarda segredos antigos e mecanismos perigosos. Suba até o topo para abrir caminho ao inimigo final.",
+    objective = {
+        type = "story",
+        target = "topo_da_torre",
+        count = 1,
+        description = "Alcance o topo da Torre dos Céus.",
+        classObjectives = {
+            guerreiro = {
+                title = "Força Inabalável",
+                description = "Quebre barreiras físicas e proteja o grupo em plataformas instáveis.",
+            },
+            arqueiro = {
+                title = "Mecanismos Precisos",
+                description = "Ative mecanismos delicados em plataformas giratórias mantendo o equilíbrio.",
+            },
+            mago = {
+                title = "Enigmas Celestes",
+                description = "Resolva enigmas mágicos para desbloquear passagens ocultas.",
+            },
+        },
+        universal = {
+            title = "Topo da Torre",
+            description = "Independentemente da função, todos devem cooperar para alcançar o topo.",
+        },
+    },
+    reward = {
+        experience = 270,
+        gold = 130,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    skybreaker_plate = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    mechanism_kit = 1,
+                },
+            },
+            mago = {
+                items = {
+                    celestial_codex = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act5/espada_lendaria.lua
+++ b/ReplicatedStorage/quests/act5/espada_lendaria.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "espada_lendaria",
+    act = 5,
+    questType = "main",
+    name = "A Espada Lendária",
+    description = "A arma lendária capaz de ferir o tirano repousa adormecida. Reúna as forças do grupo para despertá-la.",
+    objective = {
+        type = "story",
+        target = "espada_desperta",
+        count = 1,
+        description = "Obtenha a espada lendária realizando as etapas necessárias.",
+        classObjectives = {
+            guerreiro = {
+                title = "Empunhadura do Campeão",
+                description = "Empunhe a espada lendária e prepare-se para o golpe final.",
+            },
+            arqueiro = {
+                title = "Caminho da Forja",
+                description = "Localize o caminho correto até a forja perdida nas montanhas.",
+            },
+            mago = {
+                title = "Ritual de Libertação",
+                description = "Conduza o ritual mágico para libertar a espada do selo antigo.",
+            },
+        },
+        universal = {
+            title = "Espada Obtida",
+            description = "Trabalhem juntos para libertar a espada lendária e levá-la ao campo de batalha.",
+        },
+    },
+    reward = {
+        experience = 360,
+        gold = 200,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    legendary_blade = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    forja_compass = 1,
+                },
+            },
+            mago = {
+                items = {
+                    ritual_catalyst = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/ReplicatedStorage/quests/act5/reino_restaurado.lua
+++ b/ReplicatedStorage/quests/act5/reino_restaurado.lua
@@ -1,0 +1,55 @@
+local quest = {
+    id = "reino_restaurado",
+    act = 5,
+    questType = "main",
+    name = "O Reino Restaurado",
+    description = "O confronto final se aproxima. Una as forças das três classes para derrotar o tirano que ameaça o reino.",
+    objective = {
+        type = "kill",
+        target = "LordeSombrio",
+        count = 1,
+        description = "Derrote o chefe final e restaure a paz no reino.",
+        classObjectives = {
+            guerreiro = {
+                title = "Foco do Inimigo",
+                description = "Mantenha o inimigo ocupado em combate corpo a corpo e proteja os aliados.",
+            },
+            arqueiro = {
+                title = "Alvos Críticos",
+                description = "Acerte pontos críticos do chefe para abrir brechas de dano.",
+            },
+            mago = {
+                title = "Barreira Arcana",
+                description = "Proteja o grupo e neutralize as invocações com feitiços de área.",
+            },
+        },
+        universal = {
+            title = "Tirano Derrotado",
+            description = "Coordene os esforços para derrotar o chefe final e restaurar o reino.",
+        },
+    },
+    reward = {
+        experience = 420,
+        gold = 240,
+        classRewards = {
+            guerreiro = {
+                items = {
+                    royal_guard_plate = 1,
+                },
+            },
+            arqueiro = {
+                items = {
+                    royal_arrowheads = 1,
+                },
+            },
+            mago = {
+                items = {
+                    crown_sigil_cloak = 1,
+                },
+            },
+        },
+    },
+}
+
+return quest
+

--- a/tests/server/QuestManager.spec.lua
+++ b/tests/server/QuestManager.spec.lua
@@ -92,5 +92,31 @@ return function()
             inventoryController:Destroy()
             statsController:Destroy()
         end)
+
+        it("grants class specific rewards when available", function()
+            local statsController, inventoryController, questController = createControllers()
+
+            local success, err = statsController:SetClass("arqueiro")
+            expect(success).to.equal(true)
+            expect(err).to.equal(nil)
+
+            questController:AcceptQuest("primeira_caca")
+            local objective = QuestConfig.primeira_caca.objective
+            for _ = 1, objective.count do
+                questController:RegisterKill(objective.target)
+            end
+
+            local summary = questController:GetSummary()
+            expect(summary.completed.primeira_caca).to.be.ok()
+
+            local classRewards = QuestConfig.primeira_caca.reward.classRewards.arqueiro.items
+            local inventorySummary = inventoryController:GetSummary()
+            expect(inventorySummary.items.training_quiver).to.be.ok()
+            expect(inventorySummary.items.training_quiver.quantity).to.equal(classRewards.training_quiver)
+
+            questController:Destroy()
+            inventoryController:Destroy()
+            statsController:Destroy()
+        end)
     end)
 end


### PR DESCRIPTION
## Summary
- add quest modules for each act with class-specific objectives, universal progression paths, and tailored rewards
- expand quest configuration, class definitions, and item catalog to support the new mission flow
- update character and quest systems to handle player class selection and deliver class-based rewards with coverage tests

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c94d132fdc832fa8d3cf22bed73bcf