### PR TITLE
Handle migration errors gracefully

### DIFF
--- a/ServerScriptService/Main.server.lua
+++ b/ServerScriptService/Main.server.lua
@@ -15,8 +15,17 @@ local MapConfig = require(ReplicatedStorage:WaitForChild("MapConfig"))
 local MapManager = require(script.Modules.MapManager)
 
 DataMigrations.Register()
-local migrationState = DataStoreManager:RunMigrations()
-print(string.format("Migrations executadas. Versão atual: %d", migrationState.version))
+
+local migrationState
+local success, err = pcall(function()
+    migrationState = DataStoreManager:RunMigrations()
+end)
+
+if success and migrationState then
+    print(string.format("Migrations executadas. Versão atual: %d", migrationState.version))
+else
+    warn("Migrations falharam: " .. tostring(err))
+end
 
 local controllers = {}
 


### PR DESCRIPTION
## Summary
- wrap DataStoreManager:RunMigrations in a pcall to catch failures and log a warning
- ensure MapManager:EnsureLoaded executes even when migrations fail

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c968a4303c832f87b616eb4fe77ea0