### PR TITLE
Fix className keys in map models

### DIFF
--- a/Assets/Maps/CrystalCavern.model.json
+++ b/Assets/Maps/CrystalCavern.model.json
@@ -1,15 +1,15 @@
 {
-  "$className": "Model",
+  "className": "Model",
   "Name": "CrystalCavern",
   "Floor": {
-    "$className": "Part",
+    "className": "Part",
     "Name": "Floor",
     "Anchored": true,
     "Size": [96, 1, 96],
     "Position": [0, -8, 0]
   },
   "CrystalCluster": {
-    "$className": "Part",
+    "className": "Part",
     "Name": "CrystalCluster",
     "Anchored": true,
     "Size": [8, 14, 8],

--- a/Assets/Maps/StarterVillage.model.json
+++ b/Assets/Maps/StarterVillage.model.json
@@ -1,15 +1,15 @@
 {
-  "$className": "Model",
+  "className": "Model",
   "Name": "StarterVillage",
   "Ground": {
-    "$className": "Part",
+    "className": "Part",
     "Name": "Ground",
     "Anchored": true,
     "Size": [128, 1, 128],
     "Position": [0, 0.5, 0]
   },
   "CentralTree": {
-    "$className": "Part",
+    "className": "Part",
     "Name": "CentralTree",
     "Anchored": true,
     "Size": [6, 18, 6],


### PR DESCRIPTION
## Summary
- replace deprecated `$className` keys with `className` in Crystal Cavern and Starter Village model definitions
- confirmed each map object retains its intended `Name` property values

## Testing
- rojo serve

------
https://chatgpt.com/codex/tasks/task_e_68c96b2a0f78832f95d7c3d437ccacc3