### PR TITLE
Fix Rojo warnings for map models

### DIFF
--- a/Assets/Maps/CrystalCavern.model.json
+++ b/Assets/Maps/CrystalCavern.model.json
@@ -1,6 +1,6 @@
 {
   "className": "Model",
-  "Name": "CrystalCavern",
+  "NeedsPivotMigration": false,
   "Floor": {
     "className": "Part",
     "Name": "Floor",

--- a/Assets/Maps/StarterVillage.model.json
+++ b/Assets/Maps/StarterVillage.model.json
@@ -1,6 +1,6 @@
 {
   "className": "Model",
-  "Name": "StarterVillage",
+  "NeedsPivotMigration": false,
   "Ground": {
     "className": "Part",
     "Name": "Ground",


### PR DESCRIPTION
## Summary
- remove deprecated top-level Name fields from the map model assets to silence Rojo warnings
- set `NeedsPivotMigration` to `false` on both map models to avoid repeated pivot migration prompts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c96f2f6538832fa6dcda8eaa305363