### PR TITLE
Add server-side skills system with config and migrations

### DIFF
--- a/ReplicatedStorage/Remotes.lua
+++ b/ReplicatedStorage/Remotes.lua
@@ -34,6 +34,7 @@ local Remotes = {
     QuestUpdated = resolveRemote("RemoteEvent", "QuestUpdated"),
     CombatNotification = resolveRemote("RemoteEvent", "CombatNotification"),
     CombatRequest = resolveRemote("RemoteEvent", "CombatRequest"),
+    SkillRequest = resolveRemote("RemoteEvent", "SkillRequest"),
     InventoryRequest = resolveRemote("RemoteEvent", "InventoryRequest"),
 }
 

--- a/ReplicatedStorage/SkillsConfig.lua
+++ b/ReplicatedStorage/SkillsConfig.lua
@@ -1,0 +1,157 @@
+local SkillsConfig = {
+    guerreiro = {
+        power_strike = {
+            id = "power_strike",
+            name = "Golpe Poderoso",
+            description = "Canaliza força bruta para ampliar o dano dos ataques por alguns instantes.",
+            manaCost = 12,
+            cooldown = 6,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "attack",
+                    amount = 8,
+                    duration = 5,
+                },
+            },
+        },
+        iron_wall = {
+            id = "iron_wall",
+            name = "Muralha de Ferro",
+            description = "Ergue uma defesa inabalável que reduz o dano recebido.",
+            manaCost = 10,
+            cooldown = 12,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "defense",
+                    amount = 10,
+                    duration = 8,
+                },
+            },
+        },
+        battle_cry = {
+            id = "battle_cry",
+            name = "Brado de Batalha",
+            description = "Um grito inspirador que aumenta o vigor para resistir e atacar com firmeza.",
+            manaCost = 14,
+            cooldown = 18,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "attack",
+                    amount = 5,
+                    duration = 8,
+                },
+                {
+                    type = "attribute",
+                    attribute = "defense",
+                    amount = 3,
+                    duration = 8,
+                },
+            },
+        },
+    },
+    arqueiro = {
+        precise_arrow = {
+            id = "precise_arrow",
+            name = "Flecha Precisa",
+            description = "Concentração máxima para acertar pontos vitais do alvo.",
+            manaCost = 10,
+            cooldown = 6,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "attack",
+                    amount = 7,
+                    duration = 5,
+                },
+            },
+        },
+        evasive_maneuver = {
+            id = "evasive_maneuver",
+            name = "Movimento Evasivo",
+            description = "Rearranja a postura para evitar golpes inimigos.",
+            manaCost = 9,
+            cooldown = 10,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "defense",
+                    amount = 6,
+                    duration = 6,
+                },
+            },
+        },
+        tracking_focus = {
+            id = "tracking_focus",
+            name = "Foco do Rastreador",
+            description = "Energia canalizada para manter a mira estável e recuperar energia arcana.",
+            manaCost = 6,
+            cooldown = 14,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "attack",
+                    amount = 4,
+                    duration = 6,
+                },
+                {
+                    type = "mana",
+                    amount = 8,
+                },
+            },
+        },
+    },
+    mago = {
+        arcane_focus = {
+            id = "arcane_focus",
+            name = "Foco Arcano",
+            description = "Canaliza energia arcana para potencializar feitiços ofensivos.",
+            manaCost = 14,
+            cooldown = 8,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "attack",
+                    amount = 9,
+                    duration = 6,
+                },
+            },
+        },
+        mystic_barrier = {
+            id = "mystic_barrier",
+            name = "Barreira Mística",
+            description = "Cria um escudo mágico temporário para absorver dano.",
+            manaCost = 12,
+            cooldown = 16,
+            effects = {
+                {
+                    type = "attribute",
+                    attribute = "defense",
+                    amount = 7,
+                    duration = 7,
+                },
+            },
+        },
+        rejuvenating_wave = {
+            id = "rejuvenating_wave",
+            name = "Onda Revigorante",
+            description = "O fluxo de mana restaura parte da vitalidade e energia do mago.",
+            manaCost = 16,
+            cooldown = 20,
+            effects = {
+                {
+                    type = "heal",
+                    amount = 25,
+                },
+                {
+                    type = "mana",
+                    amount = 10,
+                },
+            },
+        },
+    },
+}
+
+return SkillsConfig

--- a/ServerScriptService/Modules/DataMigrations.lua
+++ b/ServerScriptService/Modules/DataMigrations.lua
@@ -115,6 +115,32 @@ local function registerMigrations()
             schemas.profile = profile
         end,
     })
+
+    DataStoreManager:RegisterMigration({
+        id = "20240505_profile_skills_structure",
+        order = 5,
+        dependencies = { "20240501_profile_schema_v1" },
+        run = function(state)
+            local schemas = ensureSchemaContainer(state)
+            local profile = schemas.profile or {}
+            local skills = profile.skills or {}
+
+            if typeof(skills.version) == "number" and skills.version >= 1 then
+                profile.skills = skills
+                schemas.profile = profile
+                return
+            end
+
+            skills.version = 1
+            skills.fields = {
+                "unlocked",
+                "hotbar",
+            }
+
+            profile.skills = skills
+            schemas.profile = profile
+        end,
+    })
 end
 
 function DataMigrations.Register()

--- a/ServerScriptService/Modules/PlayerProfileStore.lua
+++ b/ServerScriptService/Modules/PlayerProfileStore.lua
@@ -83,11 +83,20 @@ local function ensureQuests(quests)
     return quests
 end
 
+local function ensureSkills(skills)
+    skills = skills or {}
+    skills.unlocked = skills.unlocked or {}
+    skills.hotbar = skills.hotbar or {}
+    skills.version = skills.version or 1
+    return skills
+end
+
 local function ensureProfileStructure(profile)
     profile = profile or {}
     profile.stats = profile.stats or cloneDefaults()
     profile.inventory = ensureInventory(profile.inventory)
     profile.quests = ensureQuests(profile.quests)
+    profile.skills = ensureSkills(profile.skills)
     profile.currentMap = ensureCurrentMap(profile.currentMap)
     return profile
 end

--- a/ServerScriptService/Modules/Skills.lua
+++ b/ServerScriptService/Modules/Skills.lua
@@ -1,0 +1,247 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local SkillsConfig = require(ReplicatedStorage:WaitForChild("SkillsConfig"))
+local PlayerProfileStore = require(script.Parent.PlayerProfileStore)
+
+local Skills = {}
+Skills.__index = Skills
+
+local function sanitizeSkillId(value)
+    if type(value) ~= "string" then
+        return nil
+    end
+
+    local trimmed = string.match(value, "^%s*(.-)%s*$")
+    if not trimmed or trimmed == "" then
+        return nil
+    end
+
+    return string.lower(trimmed)
+end
+
+local function sanitizeNumber(value)
+    if type(value) ~= "number" then
+        return nil
+    end
+
+    if value ~= value then
+        return nil
+    end
+
+    return value
+end
+
+local timeProvider = os.clock
+
+function Skills._setTimeProvider(provider)
+    if type(provider) == "function" then
+        timeProvider = provider
+    else
+        timeProvider = os.clock
+    end
+end
+
+function Skills._resetTimeProvider()
+    timeProvider = os.clock
+end
+
+function Skills.new(player, characterStats)
+    assert(player, "Jogador é obrigatório para Skills")
+    assert(characterStats, "CharacterStats é obrigatório para Skills")
+
+    local self = setmetatable({}, Skills)
+    self.player = player
+    self.characterStats = characterStats
+    self.profile = PlayerProfileStore.Load(player)
+    self.data = self.profile.skills or {}
+    self.cooldowns = {}
+    self._destroyed = false
+
+    self:_ensureStructure()
+
+    return self
+end
+
+function Skills:_ensureStructure()
+    self.data.unlocked = self.data.unlocked or {}
+    self.data.hotbar = self.data.hotbar or {}
+    self.data.version = self.data.version or 1
+end
+
+function Skills:GetSkillsForClass(className)
+    className = className or (self.characterStats and self.characterStats:GetClass())
+    if type(className) ~= "string" then
+        return {}
+    end
+
+    local normalized = string.lower(className)
+    return SkillsConfig[normalized] or {}
+end
+
+function Skills:GetSkillDefinition(skillId)
+    local sanitized = sanitizeSkillId(skillId)
+    if not sanitized then
+        return nil
+    end
+
+    local className = self.characterStats and self.characterStats:GetClass()
+    if type(className) ~= "string" then
+        return nil
+    end
+
+    local classSkills = self:GetSkillsForClass(className)
+    return classSkills[sanitized]
+end
+
+function Skills:GetCooldownRemaining(skillId)
+    local sanitized = sanitizeSkillId(skillId)
+    if not sanitized then
+        return 0
+    end
+
+    local expiresAt = self.cooldowns[sanitized]
+    if not expiresAt then
+        return 0
+    end
+
+    local remaining = expiresAt - timeProvider()
+    if remaining <= 0 then
+        self.cooldowns[sanitized] = nil
+        return 0
+    end
+
+    return remaining
+end
+
+function Skills:_setCooldown(skillId, cooldown)
+    local duration = sanitizeNumber(cooldown) or 0
+    if duration <= 0 then
+        self.cooldowns[skillId] = nil
+        return
+    end
+
+    self.cooldowns[skillId] = timeProvider() + duration
+end
+
+function Skills:_applyEffects(skillConfig)
+    local results = {}
+    local effects = skillConfig.effects
+
+    if type(effects) ~= "table" or not self.characterStats then
+        return results
+    end
+
+    for _, effect in ipairs(effects) do
+        if type(effect) == "table" then
+            local effectType = effect.type
+            if effectType == "attribute" then
+                local attribute = effect.attribute
+                local amount = sanitizeNumber(effect.amount)
+                local duration = sanitizeNumber(effect.duration)
+                if type(attribute) == "string" and amount and amount ~= 0 and duration and duration > 0 then
+                    local applied = self.characterStats:ApplyTemporaryModifier(attribute, amount, duration)
+                    if applied then
+                        table.insert(results, {
+                            type = "attribute",
+                            attribute = attribute,
+                            amount = amount,
+                            duration = duration,
+                        })
+                    end
+                end
+            elseif effectType == "heal" then
+                local amount = sanitizeNumber(effect.amount)
+                if amount and amount > 0 then
+                    local applied = self.characterStats:RestoreHealth(amount)
+                    table.insert(results, {
+                        type = "heal",
+                        requested = amount,
+                        applied = applied,
+                    })
+                end
+            elseif effectType == "mana" then
+                local amount = sanitizeNumber(effect.amount)
+                if amount and amount > 0 then
+                    local applied = self.characterStats:RestoreMana(amount)
+                    table.insert(results, {
+                        type = "mana",
+                        requested = amount,
+                        applied = applied,
+                    })
+                end
+            elseif effectType == "experience" then
+                local amount = sanitizeNumber(effect.amount)
+                if amount and amount > 0 then
+                    self.characterStats:AddExperience(amount)
+                    table.insert(results, {
+                        type = "experience",
+                        amount = amount,
+                    })
+                end
+            end
+        end
+    end
+
+    return results
+end
+
+function Skills:UseSkill(skillId)
+    if self._destroyed then
+        return false, "Controlador de habilidades não está disponível"
+    end
+
+    if not self.characterStats then
+        return false, "Dados de personagem indisponíveis"
+    end
+
+    local sanitized = sanitizeSkillId(skillId)
+    if not sanitized then
+        return false, "skillId inválido"
+    end
+
+    local skillConfig = self:GetSkillDefinition(sanitized)
+    if not skillConfig then
+        return false, "habilidade desconhecida"
+    end
+
+    local remainingCooldown = self:GetCooldownRemaining(sanitized)
+    if remainingCooldown > 0 then
+        return false, "habilidade em recarga", {
+            code = "cooldown",
+            remaining = remainingCooldown,
+        }
+    end
+
+    local manaCost = sanitizeNumber(skillConfig.manaCost) or 0
+    if manaCost < 0 then
+        manaCost = 0
+    end
+
+    if manaCost > 0 then
+        local consumed = self.characterStats:UseMana(manaCost)
+        if not consumed then
+            return false, "mana insuficiente", {
+                code = "insufficient_mana",
+            }
+        end
+    end
+
+    self:_setCooldown(sanitized, skillConfig.cooldown)
+
+    local appliedEffects = self:_applyEffects(skillConfig)
+
+    return true, {
+        id = sanitized,
+        name = skillConfig.name,
+        cooldown = sanitizeNumber(skillConfig.cooldown) or 0,
+        manaCost = manaCost,
+        effects = appliedEffects,
+    }
+end
+
+function Skills:Destroy()
+    self._destroyed = true
+    self.cooldowns = {}
+end
+
+return Skills

--- a/tests/server/CharacterStats.spec.lua
+++ b/tests/server/CharacterStats.spec.lua
@@ -68,5 +68,25 @@ return function()
 
             statsController:Destroy()
         end)
+
+        it("aplica modificadores temporários e restaura valores originais", function()
+            local statsController = CharacterStats.new(player)
+
+            local baseline = statsController:GetStats()
+            local success = statsController:ApplyTemporaryModifier("attack", 5, 0.1)
+
+            expect(success).to.equal(true)
+            expect(statsController.stats.attack).to.equal(baseline.attack)
+
+            local buffed = statsController:GetStats()
+            expect(buffed.attack).to.equal(baseline.attack + 5)
+
+            task.wait(0.2)
+
+            local reverted = statsController:GetStats()
+            expect(reverted.attack).to.equal(baseline.attack)
+
+            statsController:Destroy()
+        end)
     end)
 end

--- a/tests/server/DataMigrations.spec.lua
+++ b/tests/server/DataMigrations.spec.lua
@@ -81,6 +81,10 @@ return function()
             expect(profileSchema.quests.states).to.be.ok()
 
             expect(MapConfig[profileSchema.stats.defaults.currentMap]).to.be.ok()
+
+            expect(profileSchema.skills).to.be.ok()
+            expect(profileSchema.skills.version).to.equal(1)
+            expect(profileSchema.skills.fields).to.be.ok()
         end)
 
         it("persists migration state between runs", function()

--- a/tests/server/Skills.spec.lua
+++ b/tests/server/Skills.spec.lua
@@ -1,0 +1,113 @@
+return function()
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local ServerScriptService = game:GetService("ServerScriptService")
+
+    local SkillsConfig = require(ReplicatedStorage:WaitForChild("SkillsConfig"))
+    local Skills = require(ServerScriptService:WaitForChild("Modules"):WaitForChild("Skills"))
+    local CharacterStats = require(ServerScriptService:WaitForChild("Modules"):WaitForChild("CharacterStats"))
+
+    local MockProfileStore = require(script.Parent.Parent.utils.MockProfileStore)
+    local TestPlayers = require(script.Parent.Parent.utils.TestPlayers)
+
+    local function deepCopy(source)
+        if type(source) ~= "table" then
+            return source
+        end
+
+        local copy = {}
+        for key, value in pairs(source) do
+            copy[key] = deepCopy(value)
+        end
+        return copy
+    end
+
+    local originalPowerStrike = deepCopy(SkillsConfig.guerreiro.power_strike)
+
+    local function restorePowerStrike()
+        local skill = SkillsConfig.guerreiro.power_strike
+        for key in pairs(skill) do
+            skill[key] = nil
+        end
+        for key, value in pairs(originalPowerStrike) do
+            skill[key] = deepCopy(value)
+        end
+    end
+
+    describe("Skills", function()
+        local mockStore
+        local player
+        local clockState
+
+        beforeAll(function()
+            mockStore = MockProfileStore.new()
+        end)
+
+        afterAll(function()
+            Skills._resetTimeProvider()
+            restorePowerStrike()
+            mockStore:restore()
+        end)
+
+        beforeEach(function()
+            mockStore:reset()
+            restorePowerStrike()
+
+            local powerStrike = SkillsConfig.guerreiro.power_strike
+            powerStrike.cooldown = 0.2
+            for _, effect in ipairs(powerStrike.effects) do
+                if effect.type == "attribute" then
+                    effect.duration = 0.1
+                end
+            end
+
+            player = TestPlayers.create("SkillsUser")
+            clockState = { value = 0 }
+            Skills._setTimeProvider(function()
+                return clockState.value
+            end)
+        end)
+
+        afterEach(function()
+            if player then
+                TestPlayers.destroy(player)
+                player = nil
+            end
+            restorePowerStrike()
+            Skills._resetTimeProvider()
+        end)
+
+        it("consome mana, aplica efeitos e respeita cooldown", function()
+            local statsController = CharacterStats.new(player)
+            local skillsController = Skills.new(player, statsController)
+
+            local baseline = statsController:GetStats()
+            local success, result = skillsController:UseSkill("power_strike")
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.id).to.equal("power_strike")
+
+            local currentStats = statsController:GetStats()
+            expect(currentStats.mana).to.equal(baseline.mana - SkillsConfig.guerreiro.power_strike.manaCost)
+            expect(currentStats.attack).to.equal(baseline.attack + SkillsConfig.guerreiro.power_strike.effects[1].amount)
+
+            local secondSuccess, _, detail = skillsController:UseSkill("power_strike")
+            expect(secondSuccess).to.equal(false)
+            expect(detail).to.be.ok()
+            expect(detail.code).to.equal("cooldown")
+
+            task.wait(0.2)
+
+            local restoredStats = statsController:GetStats()
+            expect(restoredStats.attack).to.equal(baseline.attack)
+
+            clockState.value = SkillsConfig.guerreiro.power_strike.cooldown + 0.1
+
+            local thirdSuccess = skillsController:UseSkill("power_strike")
+            expect(thirdSuccess).to.equal(true)
+
+            skillsController:Destroy()
+            statsController:Destroy()
+        end)
+    end)
+end

--- a/tests/utils/MockProfileStore.lua
+++ b/tests/utils/MockProfileStore.lua
@@ -60,6 +60,11 @@ function MockProfileStore:_createProfile()
             active = {},
             completed = {},
         },
+        skills = {
+            unlocked = {},
+            hotbar = {},
+            version = 1,
+        },
     }
 end
 


### PR DESCRIPTION
## Summary
- add a shared skills configuration describing abilities per class
- implement server-side skills module with mana usage, cooldowns, and temporary modifiers
- integrate skills with stats, migrations, remote events, and add accompanying automated tests

## Testing
- Not Run (roblox-cli not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c99929bb88832f884f70636d24972f