### PR TITLE
Add class name to StarterPlayerScripts container

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -21,6 +21,7 @@
     "StarterPlayer": {
       "$className": "StarterPlayer",
       "StarterPlayerScripts": {
+        "$className": "StarterPlayerScripts",
         "$path": "StarterPlayer/StarterPlayerScripts"
       }
     }


### PR DESCRIPTION
## Summary
- add the StarterPlayerScripts class name entry in the project configuration so Rojo creates the correct container

## Testing
- `rojo build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac0b35a4832f85f894debce3697a