### PR TITLE
Add localization support across HUDs

### DIFF
--- a/ReplicatedStorage/Localization.lua
+++ b/ReplicatedStorage/Localization.lua
@@ -6,7 +6,9 @@ Localization.languages = {
         inventory = "Inventário",
         quests = "Missões",
         activeQuests = "Missões ativas:",
+        activeQuestsTitle = "Missões Ativas",
         noActive = "(nenhuma)",
+        noActiveQuests = "Nenhuma missão ativa",
         completedQuests = "Missões concluídas:",
         level = "Nível",
         xp = "XP",
@@ -19,15 +21,56 @@ Localization.languages = {
         items = "Itens",
         equipped = "Equipados",
         none = "(nenhum)",
+        empty = "(vazio)",
         lastCombat = "Último combate:",
-        waiting = "aguardando..."
+        waiting = "aguardando...",
+        loading = "Carregando...",
+        rewardsLabel = "Recompensas",
+        rewardsPrefix = "Recompensas: %s",
+        rewardsNone = "Recompensas: nenhuma",
+        progressFormat = "Progresso: %d / %d (%d%%)",
+        abandonQuest = "Abandonar",
+        achievementsTitle = "Conquistas",
+        achievementsLockedTitle = "Em Progresso",
+        achievementsUnlockedTitle = "Conquistas Desbloqueadas",
+        achievementsProgressFormat = "Progresso: %d / %d",
+        achievementsProgressComplete = "(concluído)",
+        achievementsUnlockedAtFormat = "Conquistado em %d/%m/%Y %H:%M",
+        achievementsNoneInProgress = "Nenhuma conquista em andamento",
+        achievementsNoneUnlocked = "Nenhuma conquista desbloqueada",
+        shopTitle = "Lojas",
+        shopSelectPrompt = "Selecione uma loja",
+        shopDefaultName = "loja",
+        shopSelectMessage = "Selecione uma loja para visualizar os itens disponíveis.",
+        bundleNameFormat = "%s (Pacote x%d)",
+        bundleDetails = "Pacote: %d itens",
+        maxPurchase = "Máx compra: %d",
+        quantityPlaceholder = "Qtd",
+        buy = "Comprar",
+        locked = "Bloqueado",
+        shopSelectBeforeBuying = "Selecione uma loja antes de comprar.",
+        invalidQuantity = "Informe uma quantidade válida.",
+        quantityMinimum = "A quantidade deve ser pelo menos 1.",
+        shopNoItems = "Nenhum item disponível nesta loja no momento.",
+        shopShowItems = "Mostrando %d itens em %s.",
+        shopRequestItems = "Solicitando itens de %s...",
+        shopOpenFallbackError = "Não foi possível abrir a loja.",
+        purchaseSuccessFormat = "Compra concluída: %s x%d",
+        purchaseFailureFallback = "Compra não realizada.",
+        currencyGoldFormat = "%d ouro",
+        currencyGenericFormat = "%d %s",
+        combatAttack = "%s atacou %s causando %d de dano%s",
+        combatDefeatedSuffix = " (inimigo derrotado)",
+        combatUsingWeapon = " usando %s",
     },
     ["en"] = {
         stats = "Stats",
         inventory = "Inventory",
         quests = "Quests",
         activeQuests = "Active quests:",
+        activeQuestsTitle = "Active Quests",
         noActive = "(none)",
+        noActiveQuests = "No active quests",
         completedQuests = "Completed quests:",
         level = "Level",
         xp = "XP",
@@ -40,22 +83,83 @@ Localization.languages = {
         items = "Items",
         equipped = "Equipped",
         none = "(none)",
+        empty = "(empty)",
         lastCombat = "Last combat:",
-        waiting = "waiting..."
+        waiting = "waiting...",
+        loading = "Loading...",
+        rewardsLabel = "Rewards",
+        rewardsPrefix = "Rewards: %s",
+        rewardsNone = "Rewards: none",
+        progressFormat = "Progress: %d / %d (%d%%)",
+        abandonQuest = "Abandon",
+        achievementsTitle = "Achievements",
+        achievementsLockedTitle = "In Progress",
+        achievementsUnlockedTitle = "Unlocked Achievements",
+        achievementsProgressFormat = "Progress: %d / %d",
+        achievementsProgressComplete = "(complete)",
+        achievementsUnlockedAtFormat = "Unlocked on %m/%d/%Y %H:%M",
+        achievementsNoneInProgress = "No achievements in progress",
+        achievementsNoneUnlocked = "No achievements unlocked",
+        shopTitle = "Shops",
+        shopSelectPrompt = "Select a shop",
+        shopDefaultName = "shop",
+        shopSelectMessage = "Select a shop to view the available items.",
+        bundleNameFormat = "%s (Bundle x%d)",
+        bundleDetails = "Bundle: %d items",
+        maxPurchase = "Max purchase: %d",
+        quantityPlaceholder = "Qty",
+        buy = "Buy",
+        locked = "Locked",
+        shopSelectBeforeBuying = "Select a shop before purchasing.",
+        invalidQuantity = "Enter a valid quantity.",
+        quantityMinimum = "Quantity must be at least 1.",
+        shopNoItems = "No items are available in this shop right now.",
+        shopShowItems = "Showing %d items in %s.",
+        shopRequestItems = "Requesting items from %s...",
+        shopOpenFallbackError = "Unable to open the shop.",
+        purchaseSuccessFormat = "Purchase completed: %s x%d",
+        purchaseFailureFallback = "Purchase failed.",
+        currencyGoldFormat = "%d gold",
+        currencyGenericFormat = "%d %s",
+        combatAttack = "%s attacked %s dealing %d damage%s",
+        combatDefeatedSuffix = " (enemy defeated)",
+        combatUsingWeapon = " using %s",
     },
 }
+
+local languageChangedEvent = Instance.new("BindableEvent")
+languageChangedEvent.Name = "LocalizationLanguageChanged"
 
 Localization.currentLanguage = "pt"
 
 function Localization.setLanguage(lang)
-    if Localization.languages[lang] then
+    if Localization.languages[lang] and Localization.currentLanguage ~= lang then
         Localization.currentLanguage = lang
+        languageChangedEvent:Fire(lang)
     end
 end
 
 function Localization.get(key)
     local langTable = Localization.languages[Localization.currentLanguage]
     return (langTable and langTable[key]) or key
+end
+
+function Localization.format(key, ...)
+    local value = Localization.get(key)
+    local argCount = select("#", ...)
+    if argCount > 0 then
+        return string.format(value, ...)
+    end
+    return value
+end
+
+function Localization.onLanguageChanged(callback)
+    assert(type(callback) == "function", "callback must be a function")
+    return languageChangedEvent.Event:Connect(callback)
+end
+
+function Localization.getCurrentLanguage()
+    return Localization.currentLanguage
 end
 
 return Localization

--- a/StarterGui/RPGHud.client.lua
+++ b/StarterGui/RPGHud.client.lua
@@ -3,6 +3,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local Remotes = require(ReplicatedStorage:WaitForChild("Remotes"))
 local ItemsConfig = require(ReplicatedStorage:WaitForChild("ItemsConfig"))
+local Localization = require(ReplicatedStorage:WaitForChild("Localization"))
 
 local player = Players.LocalPlayer
 local playerGui = player:WaitForChild("PlayerGui")
@@ -24,7 +25,7 @@ local function createLabel(name, position)
     label.TextYAlignment = Enum.TextYAlignment.Top
     label.Size = UDim2.new(0, 280, 0, 180)
     label.Position = position
-    label.Text = "Carregando..."
+    label.Text = Localization.get("loading")
     label.Parent = screenGui
     return label
 end
@@ -33,40 +34,49 @@ local statsLabel = createLabel("StatsLabel", UDim2.new(0, 20, 0, 20))
 local inventoryLabel = createLabel("InventoryLabel", UDim2.new(0, 320, 0, 20))
 local combatLabel = createLabel("CombatLabel", UDim2.new(0, 20, 0, 220))
 combatLabel.Size = UDim2.new(0, 280, 0, 80)
-combatLabel.Text = "Último combate: aguardando..."
+combatLabel.Text = string.format("%s %s", Localization.get("lastCombat"), Localization.get("waiting"))
+
+local lastStats
+local lastInventory
+local lastCombatEvent
 
 local function renderStats(stats)
+    lastStats = stats
+
     if not stats then
-        return
-    end
-
-    statsLabel.Text = string.format(
-        "Nível: %d\nXP: %d\nVida: %d / %d\nMana: %d / %d\nAtaque: %d\nDefesa: %d\nOuro: %d",
-        stats.level or 1,
-        stats.experience or 0,
-        stats.health or 0,
-        stats.maxHealth or 0,
-        stats.mana or 0,
-        stats.maxMana or 0,
-        stats.attack or 0,
-        stats.defense or 0,
-        stats.gold or 0
-    )
-end
-
-local function renderInventory(summary)
-    if not summary then
+        statsLabel.Text = Localization.get("loading")
         return
     end
 
     local lines = {
-        string.format("Capacidade: %d", summary.capacity or 0),
-        "Itens:",
+        string.format("%s: %d", Localization.get("level"), stats.level or 1),
+        string.format("%s: %d", Localization.get("xp"), stats.experience or 0),
+        string.format("%s: %d / %d", Localization.get("health"), stats.health or 0, stats.maxHealth or 0),
+        string.format("%s: %d / %d", Localization.get("mana"), stats.mana or 0, stats.maxMana or 0),
+        string.format("%s: %d", Localization.get("attack"), stats.attack or 0),
+        string.format("%s: %d", Localization.get("defense"), stats.defense or 0),
+        string.format("%s: %d", Localization.get("gold"), stats.gold or 0),
+    }
+
+    statsLabel.Text = table.concat(lines, "\n")
+end
+
+local function renderInventory(summary)
+    lastInventory = summary
+
+    if not summary then
+        inventoryLabel.Text = Localization.get("loading")
+        return
+    end
+
+    local lines = {
+        string.format("%s: %d", Localization.get("capacity"), summary.capacity or 0),
+        Localization.get("items") .. ":",
     }
 
     local items = summary.items or {}
     if next(items) == nil then
-        table.insert(lines, "  (vazio)")
+        table.insert(lines, "  " .. Localization.get("empty"))
     else
         for _, entry in pairs(items) do
             local itemConfig = ItemsConfig[entry.id]
@@ -75,10 +85,10 @@ local function renderInventory(summary)
         end
     end
 
-    table.insert(lines, "Equipados:")
+    table.insert(lines, Localization.get("equipped") .. ":")
     local equipped = summary.equipped or {}
     if next(equipped) == nil then
-        table.insert(lines, "  (nenhum)")
+        table.insert(lines, "  " .. Localization.get("none"))
     else
         for slot, itemId in pairs(equipped) do
             local itemConfig = ItemsConfig[itemId]
@@ -91,22 +101,26 @@ local function renderInventory(summary)
 end
 
 local function handleCombat(event)
+    lastCombatEvent = event
+
     if not event then
+        combatLabel.Text = string.format("%s %s", Localization.get("lastCombat"), Localization.get("waiting"))
         return
     end
 
-    local text = string.format(
-        "%s atacou %s causando %d de dano%s",
+    local defeatedSuffix = event.defeated and Localization.get("combatDefeatedSuffix") or ""
+    local text = Localization.format(
+        "combatAttack",
         event.attacker or "?",
         event.target or "?",
         event.damage or 0,
-        event.defeated and " (inimigo derrotado)" or ""
+        defeatedSuffix
     )
 
     if event.weapon then
         local weaponConfig = ItemsConfig[event.weapon]
         local weaponName = weaponConfig and weaponConfig.name or event.weapon
-        text = text .. string.format(" usando %s", weaponName)
+        text ..= Localization.format("combatUsingWeapon", weaponName)
     end
 
     combatLabel.Text = text
@@ -115,4 +129,10 @@ end
 Remotes.StatsUpdated.OnClientEvent:Connect(renderStats)
 Remotes.InventoryUpdated.OnClientEvent:Connect(renderInventory)
 Remotes.CombatNotification.OnClientEvent:Connect(handleCombat)
+
+Localization.onLanguageChanged(function()
+    renderStats(lastStats)
+    renderInventory(lastInventory)
+    handleCombat(lastCombatEvent)
+end)
 

--- a/StarterPlayer/StarterPlayerScripts/LocalizationController.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/LocalizationController.client.lua
@@ -1,0 +1,21 @@
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+local Localization = require(ReplicatedStorage:WaitForChild("Localization"))
+
+local player = Players.LocalPlayer
+
+local function applyLanguageAttribute()
+    local language = player:GetAttribute("Language")
+    if typeof(language) == "string" then
+        Localization.setLanguage(language)
+    end
+end
+
+if typeof(player:GetAttribute("Language")) ~= "string" then
+    player:SetAttribute("Language", Localization.getCurrentLanguage())
+else
+    applyLanguageAttribute()
+end
+
+player:GetAttributeChangedSignal("Language"):Connect(applyLanguageAttribute)


### PR DESCRIPTION
## Summary
- extend the shared localization dictionary with new UI labels, runtime language change support, and formatting helpers
- localize the RPG, quest, achievement, and shop HUDs and allow them to react to language changes via the new controller
- synchronize player language via a starter script and expand the quest HUD client tests to assert localized rendering in Portuguese and English

## Testing
- Unable to run automated tests locally (roblox-cli tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9d82d6a14832f880383c69a99803a