### PR TITLE
Add server-side map travel handling

### DIFF
--- a/ReplicatedStorage/MapConfig.lua
+++ b/ReplicatedStorage/MapConfig.lua
@@ -9,6 +9,10 @@ local MapConfig = {
             plaza = CFrame.new(0, 5, 0),
             blacksmith = CFrame.new(24, 5, -16),
         },
+        travel = {
+            minLevel = 1,
+            allowedSpawns = { "plaza", "blacksmith" },
+        },
     },
 
     crystal_cavern = {
@@ -18,6 +22,15 @@ local MapConfig = {
         spawns = {
             entrance = CFrame.new(-12, 6, 32),
             sanctuary = CFrame.new(18, 10, -40),
+        },
+        travel = {
+            minLevel = 5,
+            allowedSpawns = { "entrance", "sanctuary" },
+            spawnRequirements = {
+                sanctuary = {
+                    minLevel = 10,
+                },
+            },
         },
     },
 }

--- a/ReplicatedStorage/Remotes.lua
+++ b/ReplicatedStorage/Remotes.lua
@@ -37,6 +37,7 @@ local Remotes = {
     SkillRequest = resolveRemote("RemoteEvent", "SkillRequest"),
     InventoryRequest = resolveRemote("RemoteEvent", "InventoryRequest"),
     CraftingRequest = resolveRemote("RemoteEvent", "CraftingRequest"),
+    MapTravelRequest = resolveRemote("RemoteEvent", "MapTravelRequest"),
     ShopOpen = resolveRemote("RemoteEvent", "ShopOpen"),
     ShopPurchase = resolveRemote("RemoteEvent", "ShopPurchase"),
     AchievementUpdated = resolveRemote("RemoteEvent", "AchievementUpdated"),

--- a/ServerScriptService/Modules/MapManager.lua
+++ b/ServerScriptService/Modules/MapManager.lua
@@ -120,6 +120,12 @@ function MapManager:GetSpawnCFrame(mapId, spawnId)
     return cframe
 end
 
+function MapManager:ResolveSpawn(mapId, spawnId)
+    local targetMapId = mapId or self.currentMapId or DEFAULT_MAP_ID
+    local cframe, resolvedSpawn = resolveSpawn(targetMapId, spawnId)
+    return cframe, resolvedSpawn
+end
+
 function MapManager:GetPlayerMap(player)
     local spawnData = self.playerSpawns[player]
     return spawnData and spawnData.mapId or nil
@@ -172,7 +178,7 @@ function MapManager:SpawnPlayer(player, mapId, spawnId)
 
     local targetMapId = mapId or self.currentMapId or DEFAULT_MAP_ID
     local mapModel = self:EnsureLoaded(targetMapId)
-    local spawnCFrame, resolvedSpawn = resolveSpawn(targetMapId, spawnId)
+    local spawnCFrame, resolvedSpawn = self:ResolveSpawn(targetMapId, spawnId)
 
     local existingConnection = self.playerConnections[player]
     if existingConnection then

--- a/tests/server/MapTravelRequest.spec.lua
+++ b/tests/server/MapTravelRequest.spec.lua
@@ -1,0 +1,156 @@
+return function()
+    local Workspace = game:GetService("Workspace")
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local ServerScriptService = game:GetService("ServerScriptService")
+
+    local MapManager = require(ServerScriptService:WaitForChild("Modules"):WaitForChild("MapManager"))
+    local Remotes = require(ReplicatedStorage:WaitForChild("Remotes"))
+
+    local MockProfileStore = require(script.Parent.Parent.utils.MockProfileStore)
+    local TestPlayers = require(script.Parent.Parent.utils.TestPlayers)
+
+    local function destroyMapInstances()
+        for _, instance in ipairs(Workspace:GetChildren()) do
+            if instance:IsA("Model") then
+                if instance.Name == "StarterVillage" or instance.Name == "CrystalCavern" then
+                    instance:Destroy()
+                end
+            end
+        end
+    end
+
+    describe("MapTravelRequest", function()
+        local mockStore
+        local controllers
+        local createdPlayers
+
+        local function createTestPlayer(name)
+            local player = TestPlayers.create(name)
+            table.insert(createdPlayers, player)
+            task.wait()
+            return player
+        end
+
+        local function cleanupPlayers()
+            if not createdPlayers then
+                return
+            end
+
+            for index = #createdPlayers, 1, -1 do
+                local player = createdPlayers[index]
+                TestPlayers.destroy(player)
+            end
+            createdPlayers = {}
+            task.wait()
+        end
+
+        beforeAll(function()
+            mockStore = MockProfileStore.new()
+            controllers = require(ServerScriptService:WaitForChild("Main"))
+            expect(Remotes.MapTravelRequest).to.be.ok()
+            createdPlayers = {}
+        end)
+
+        afterAll(function()
+            cleanupPlayers()
+            destroyMapInstances()
+            MapManager:Unload()
+            mockStore:restore()
+        end)
+
+        beforeEach(function()
+            createdPlayers = {}
+            mockStore:reset()
+            destroyMapInstances()
+            MapManager:Unload()
+        end)
+
+        afterEach(function()
+            cleanupPlayers()
+            destroyMapInstances()
+            MapManager:Unload()
+        end)
+
+        it("allows players to travel when requirements are met", function()
+            local player = createTestPlayer("ValidTraveler")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            controller.stats.stats.level = 20
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "crystal_cavern",
+                spawnId = "sanctuary",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("crystal_cavern")
+            expect(result.resolvedSpawn).to.equal("sanctuary")
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("crystal_cavern")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("crystal_cavern")
+            expect(spawnData.spawnName).to.equal("sanctuary")
+        end)
+
+        it("rejects travel for unknown maps", function()
+            local player = createTestPlayer("UnknownMap")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            controller.stats.stats.level = 20
+
+            local initialProfile = mockStore:getProfile(player)
+            local initialMap = initialProfile.currentMap
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "missing_world",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.be.ok()
+            expect(mockStore:getProfile(player).currentMap).to.equal(initialMap)
+            expect(MapManager:GetPlayerMap(player)).to.equal(initialMap)
+        end)
+
+        it("rejects travel when player level is below the map requirement", function()
+            local player = createTestPlayer("LowLevelTraveler")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            controller.stats.stats.level = 3
+
+            local currentMap = MapManager:GetPlayerMap(player)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "crystal_cavern",
+                spawnId = "entrance",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+            expect(MapManager:GetPlayerMap(player)).to.equal(currentMap)
+            expect(mockStore:getProfile(player).currentMap).to.equal(currentMap)
+        end)
+
+        it("rejects travel when spawn requirements are not satisfied", function()
+            local player = createTestPlayer("SpawnLockedTraveler")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            controller.stats.stats.level = 6
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "crystal_cavern",
+                spawnId = "sanctuary",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente para o spawn")
+        end)
+    end)
+end


### PR DESCRIPTION
## Summary
- add map travel requirements to the shared configuration and register the MapTravelRequest remote
- validate map travel requests on the server with rate limiting, calling MapManager and persisting the selected map
- expose spawn resolution in MapManager and add server-side tests covering valid travel and rejection scenarios

## Testing
- roblox-cli --version *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9de242bf0832fb7b84c5760cfea31