### PR TITLE
Add quest-based achievements and bindings

### DIFF
--- a/ReplicatedStorage/AchievementConfig.lua
+++ b/ReplicatedStorage/AchievementConfig.lua
@@ -52,6 +52,31 @@ local AchievementConfig = {
                 experience = 150,
             },
         },
+        quest_novice = {
+            name = "Novato em Missões",
+            description = "Conclua a missão 'Suprimentos de Ervas'.",
+            condition = {
+                type = "quest",
+                target = "gather_herbs",
+                threshold = 1,
+            },
+            reward = {
+                gold = 30,
+            },
+        },
+        quest_adept = {
+            name = "Adepto das Missões",
+            description = "Conclua duas missões quaisquer.",
+            condition = {
+                type = "quest",
+                threshold = 2,
+            },
+            reward = {
+                items = {
+                    potion_small = 1,
+                },
+            },
+        },
     },
 }
 

--- a/ServerScriptService/Main.server.lua
+++ b/ServerScriptService/Main.server.lua
@@ -475,7 +475,7 @@ local function createPlayerControllers(player)
     local skills = Skills.new(player, stats)
     local crafting = Crafting.new(player, inventory)
     local shop = ShopManager.new(player, stats, inventory)
-    local achievements = AchievementManager.new(player, stats, inventory, combat)
+    local achievements = AchievementManager.new(player, stats, inventory, combat, quests)
 
     controllers[player] = {
         stats = stats,

--- a/ServerScriptService/Modules/QuestManager.lua
+++ b/ServerScriptService/Modules/QuestManager.lua
@@ -137,6 +137,7 @@ function QuestManager.new(player, characterStats, inventory)
     self.inventory = inventory
     self.profile = PlayerProfileStore.Load(player)
     self.data = self.profile.quests
+    self.achievementManager = nil
     self:_ensureStructure()
     self:_pushUpdate()
     return self
@@ -226,6 +227,10 @@ function QuestManager:_completeQuest(questId, entry)
 
     self.data.active[questId] = nil
     self.data.completed[questId] = entry
+
+    if self.achievementManager and self.achievementManager.OnQuestCompleted then
+        self.achievementManager:OnQuestCompleted(questId)
+    end
 
     self:_grantRewards(definition)
     self:_save()
@@ -320,7 +325,18 @@ function QuestManager:RegisterCollection(target, amount)
 end
 
 function QuestManager:Destroy()
+    self.achievementManager = nil
     PlayerProfileStore.Save(self.player)
+end
+
+function QuestManager:BindAchievementManager(manager)
+    self.achievementManager = manager
+end
+
+function QuestManager:UnbindAchievementManager(manager)
+    if manager == nil or manager == self.achievementManager then
+        self.achievementManager = nil
+    end
 end
 
 return QuestManager


### PR DESCRIPTION
## Summary
- index quest-based achievement definitions and wire quest completion notifications through AchievementManager
- allow AchievementManager to bind to QuestManager instances and update QuestManager to notify achievements when quests finish
- add quest achievements to the shared config and cover the new flow with updated server specs

## Testing
- not run (roblox-cli unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9e602d21c832f8438a51987422c15