### PR TITLE
Add late-game guardian armor set

### DIFF
--- a/ReplicatedStorage/ItemsConfig.lua
+++ b/ReplicatedStorage/ItemsConfig.lua
@@ -359,6 +359,28 @@ local ItemsConfig = {
             defense = 20,
         },
     },
+    guardian_greaves = {
+        id = "guardian_greaves",
+        name = "Grevas do Guardião",
+        type = "equipment",
+        slot = "boots",
+        description = "Grevas reforçadas que mantêm os guardiões firmes mesmo sob grande pressão.",
+        attributes = {
+            defense = 14,
+            knockbackResistChance = 0.35,
+        },
+    },
+    sentinel_helm = {
+        id = "sentinel_helm",
+        name = "Elmo do Sentinela",
+        type = "equipment",
+        slot = "helmet",
+        description = "Elmo venerado pelos sentinelas que vigiam a cidadela renascida.",
+        attributes = {
+            defense = 12,
+            maxHealth = 120,
+        },
+    },
     royal_arrowheads = {
         id = "royal_arrowheads",
         name = "Pontas Reais",
@@ -439,6 +461,22 @@ ItemsConfig.recipes = {
             guardian_blade = 1,
             dragonbane_arrows = 2,
             forja_compass = 1,
+        },
+    },
+    guardian_greaves = {
+        result = "guardian_greaves",
+        ingredients = {
+            cristal_vulcanico = 4,
+            forja_compass = 1,
+            essencia_alquimica = 2,
+        },
+    },
+    sentinel_helm = {
+        result = "sentinel_helm",
+        ingredients = {
+            forja_compass = 1,
+            cristal_vulcanico = 2,
+            ritual_catalyst = 1,
         },
     },
 }

--- a/ReplicatedStorage/ShopConfig.lua
+++ b/ReplicatedStorage/ShopConfig.lua
@@ -68,6 +68,15 @@ local ShopConfig = {
                     minLevel = 2,
                 },
             },
+            {
+                itemId = "guardian_greaves",
+                price = 360,
+                quantity = 1,
+                requirements = {
+                    minLevel = 5,
+                    classes = { "guerreiro" },
+                },
+            },
         },
     },
 }

--- a/ReplicatedStorage/quests/act5/reino_restaurado.lua
+++ b/ReplicatedStorage/quests/act5/reino_restaurado.lua
@@ -35,6 +35,7 @@ local quest = {
             guerreiro = {
                 items = {
                     royal_guard_plate = 1,
+                    sentinel_helm = 1,
                 },
             },
             arqueiro = {


### PR DESCRIPTION
## Summary
- add the guardian greaves and sentinel helm equipment entries with high-tier attributes
- require late-act materials to craft the new gear
- surface the boots through the arcane repository shop and award the helm from the Act V finale quest

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9f3e8a548832f85dbfe560b448c1b