### PR TITLE
Add scout longbow and camouflage cloak equipment

### DIFF
--- a/ReplicatedStorage/ItemsConfig.lua
+++ b/ReplicatedStorage/ItemsConfig.lua
@@ -381,11 +381,33 @@ local ItemsConfig = {
             maxHealth = 120,
         },
     },
+    scout_longbow = {
+        id = "scout_longbow",
+        name = "Arco Longo do Batedor",
+        type = "equipment",
+        slot = "weapon",
+        description = "Arco longínquo usado por batedores para acertar alvos com precisão letal.",
+        attributes = {
+            attack = 14,
+            criticalChance = 0.12,
+        },
+    },
     royal_arrowheads = {
         id = "royal_arrowheads",
         name = "Pontas Reais",
         type = "material",
         description = "Pontas de flecha forjadas com precisão para acertar pontos críticos.",
+    },
+    camouflage_cloak = {
+        id = "camouflage_cloak",
+        name = "Manto de Camuflagem",
+        type = "equipment",
+        slot = "cloak",
+        description = "Manto texturizado que se mistura à vegetação, dificultando ser encontrado.",
+        attributes = {
+            defense = 7,
+            detectionReduction = 0.25,
+        },
     },
     crown_sigil_cloak = {
         id = "crown_sigil_cloak",
@@ -446,6 +468,13 @@ ItemsConfig.recipes = {
         ingredients = {
             training_quiver = 1,
             precision_string = 1,
+        },
+    },
+    scout_longbow = {
+        result = "scout_longbow",
+        ingredients = {
+            precision_string = 1,
+            royal_arrowheads = 1,
         },
     },
     molten_gauntlets = {

--- a/ReplicatedStorage/ShopConfig.lua
+++ b/ReplicatedStorage/ShopConfig.lua
@@ -69,6 +69,15 @@ local ShopConfig = {
                 },
             },
             {
+                itemId = "scout_longbow",
+                price = 220,
+                quantity = 1,
+                requirements = {
+                    minLevel = 4,
+                    classes = { "arqueiro" },
+                },
+            },
+            {
                 itemId = "guardian_greaves",
                 price = 360,
                 quantity = 1,


### PR DESCRIPTION
## Summary
- add scout longbow and camouflage cloak equipment entries with appropriate attributes in ItemsConfig
- register a crafting recipe for the scout longbow using existing materials
- list the scout longbow for sale in the arcane repository shop for mid-tier archers

## Testing
- selene --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f6c57870832f94f747f48dd2a2ff