### PR TITLE
Add archon robe equipment for mid-level mages

### DIFF
--- a/ReplicatedStorage/ItemsConfig.lua
+++ b/ReplicatedStorage/ItemsConfig.lua
@@ -409,6 +409,18 @@ local ItemsConfig = {
             detectionReduction = 0.25,
         },
     },
+    archon_robe = {
+        id = "archon_robe",
+        name = "Veste do Arconte",
+        type = "equipment",
+        slot = "armor",
+        description = "Veste rúnica criada para magos que dominam rituais intermediários.",
+        attributes = {
+            defense = 13,
+            maxMana = 25,
+            manaRegen = 4,
+        },
+    },
     crown_sigil_cloak = {
         id = "crown_sigil_cloak",
         name = "Manto do Selo Real",
@@ -505,6 +517,13 @@ ItemsConfig.recipes = {
         ingredients = {
             forja_compass = 1,
             cristal_vulcanico = 2,
+            ritual_catalyst = 1,
+        },
+    },
+    archon_robe = {
+        result = "archon_robe",
+        ingredients = {
+            essencia_alquimica = 3,
             ritual_catalyst = 1,
         },
     },

--- a/ReplicatedStorage/ShopConfig.lua
+++ b/ReplicatedStorage/ShopConfig.lua
@@ -61,6 +61,15 @@ local ShopConfig = {
                 },
             },
             {
+                itemId = "archon_robe",
+                price = 240,
+                quantity = 1,
+                requirements = {
+                    minLevel = 4,
+                    classes = { "mago" },
+                },
+            },
+            {
                 itemId = "trail_lantern",
                 price = 80,
                 quantity = 1,


### PR DESCRIPTION
## Summary
- add the archon robe mid-tier armor for mages with balanced defensive and mana-focused stats
- introduce a crafting recipe using essencia_alquimica and ritual_catalyst to create the new robe
- list the robe in the arcane repository shop for magicians starting at level 4

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9f7e46000832fac2a012dd9715a76