### PR TITLE
Add volcanic crater map support

### DIFF
--- a/Assets/Maps/VolcanicCrater.model.json
+++ b/Assets/Maps/VolcanicCrater.model.json
@@ -1,0 +1,124 @@
+{
+  "className": "Model",
+  "Name": "VolcanicCrater",
+  "NeedsPivotMigration": false,
+  "CraterBase": {
+    "className": "Part",
+    "Name": "CraterBase",
+    "Anchored": true,
+    "Size": [240, 4, 240],
+    "Position": [0, -4, 0]
+  },
+  "EntranceRamp": {
+    "className": "Part",
+    "Name": "EntranceRamp",
+    "Anchored": true,
+    "Size": [36, 4, 80],
+    "Position": [0, 2, 104]
+  },
+  "EntrancePlatform": {
+    "className": "Part",
+    "Name": "EntrancePlatform",
+    "Anchored": true,
+    "Size": [44, 2, 44],
+    "Position": [0, 8, 72]
+  },
+  "CentralChamberPlatform": {
+    "className": "Part",
+    "Name": "CentralChamberPlatform",
+    "Anchored": true,
+    "Size": [56, 4, 56],
+    "Position": [0, 8, 0]
+  },
+  "CentralChamberRing": {
+    "className": "Part",
+    "Name": "CentralChamberRing",
+    "Anchored": true,
+    "Size": [84, 2, 84],
+    "Position": [0, 6, 0]
+  },
+  "BridgeToCore": {
+    "className": "Part",
+    "Name": "BridgeToCore",
+    "Anchored": true,
+    "Size": [12, 2, 60],
+    "Position": [0, 8, 36]
+  },
+  "LavaRiverWest": {
+    "className": "Part",
+    "Name": "LavaRiverWest",
+    "Anchored": true,
+    "Size": [12, 2, 160],
+    "Position": [-52, -1, 0]
+  },
+  "LavaRiverEast": {
+    "className": "Part",
+    "Name": "LavaRiverEast",
+    "Anchored": true,
+    "Size": [12, 2, 160],
+    "Position": [52, -1, 0]
+  },
+  "LavaLake": {
+    "className": "Part",
+    "Name": "LavaLake",
+    "Anchored": true,
+    "Size": [96, 2, 72],
+    "Position": [0, -2, -72]
+  },
+  "MagmaFall": {
+    "className": "Part",
+    "Name": "MagmaFall",
+    "Anchored": true,
+    "Size": [20, 16, 8],
+    "Position": [0, 12, -108]
+  },
+  "HarvestShelfWest": {
+    "className": "Part",
+    "Name": "HarvestShelfWest",
+    "Anchored": true,
+    "Size": [38, 2, 38],
+    "Position": [-70, 10, 54]
+  },
+  "HarvestShelfEast": {
+    "className": "Part",
+    "Name": "HarvestShelfEast",
+    "Anchored": true,
+    "Size": [34, 2, 34],
+    "Position": [68, 12, -58]
+  },
+  "ResourceClusterAlpha": {
+    "className": "Part",
+    "Name": "ResourceClusterAlpha",
+    "Anchored": true,
+    "Size": [12, 12, 12],
+    "Position": [-70, 16, 54]
+  },
+  "ResourceClusterBeta": {
+    "className": "Part",
+    "Name": "ResourceClusterBeta",
+    "Anchored": true,
+    "Size": [10, 10, 10],
+    "Position": [68, 18, -58]
+  },
+  "ObservationSpireBase": {
+    "className": "Part",
+    "Name": "ObservationSpireBase",
+    "Anchored": true,
+    "Size": [18, 2, 18],
+    "Position": [96, 8, 18]
+  },
+  "ObservationSpire": {
+    "className": "Part",
+    "Name": "ObservationSpire",
+    "Anchored": true,
+    "Size": [10, 26, 10],
+    "Position": [96, 22, 18]
+  },
+  "BasaltArch": {
+    "className": "Part",
+    "Name": "BasaltArch",
+    "Anchored": true,
+    "Size": [64, 4, 12],
+    "Position": [-24, 14, -44]
+  }
+}

--- a/ReplicatedStorage/MapConfig.lua
+++ b/ReplicatedStorage/MapConfig.lua
@@ -75,6 +75,29 @@ local MapConfig = {
             },
         },
     },
+
+    volcanic_crater = {
+        name = "Cratera Vulcânica",
+        assetName = "VolcanicCrater",
+        defaultSpawn = "entrance",
+        spawns = {
+            entrance = CFrame.new(0, 9, 72),
+            central_chamber = CFrame.new(0, 10, 0),
+            observation_spire = CFrame.new(96, 10, 18),
+        },
+        travel = {
+            minLevel = 26,
+            allowedSpawns = { "entrance", "central_chamber", "observation_spire" },
+            spawnRequirements = {
+                central_chamber = {
+                    minLevel = 32,
+                },
+                observation_spire = {
+                    minLevel = 34,
+                },
+            },
+        },
+    },
 }
 
 return MapConfig

--- a/ServerScriptService/Main.server.lua
+++ b/ServerScriptService/Main.server.lua
@@ -358,6 +358,7 @@ local function validateMapTravelRequest(player, controller, request)
         mapId = mapId,
         spawnId = spawnId,
         resolvedSpawn = resolvedSpawnName,
+        resolvedSpawnCFrame = resolvedSpawnCFrame,
     }
 end
 

--- a/tests/server/MapManager.spec.lua
+++ b/tests/server/MapManager.spec.lua
@@ -68,6 +68,13 @@ return function()
             expect(MapManager:GetCurrentMapId()).to.equal("desert_outpost")
         end)
 
+        it("loads the volcanic crater map when requested", function()
+            local craterModel = MapManager:Load("volcanic_crater")
+            expect(craterModel.Parent).to.equal(Workspace)
+            expect(craterModel.Name).to.equal("VolcanicCrater")
+            expect(MapManager:GetCurrentMapId()).to.equal("volcanic_crater")
+        end)
+
         it("spawns players at the configured positions", function()
             local spawnCFrame = MapManager:GetSpawnCFrame("starter_village", "blacksmith")
             MapManager:SpawnPlayer(player, "starter_village", "blacksmith")

--- a/tests/server/MapTravelRequest.spec.lua
+++ b/tests/server/MapTravelRequest.spec.lua
@@ -110,6 +110,7 @@ return function()
             expect(result).to.be.ok()
             expect(result.mapId).to.equal("crystal_cavern")
             expect(result.resolvedSpawn).to.equal("sanctuary")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("crystal_cavern", "sanctuary"))
 
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("crystal_cavern")
@@ -192,6 +193,7 @@ return function()
             expect(result).to.be.ok()
             expect(result.mapId).to.equal("desert_outpost")
             expect(result.resolvedSpawn).to.equal("camp")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("desert_outpost", "camp"))
 
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("desert_outpost")
@@ -216,6 +218,55 @@ return function()
 
             expect(success).to.equal(false)
             expect(reason).to.equal("nível insuficiente para o spawn")
+        end)
+
+        it("rejects travel to the volcanic crater when below the map requirement", function()
+            local player = createTestPlayer("VolcanicLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 24)
+
+            local currentMap = MapManager:GetPlayerMap(player)
+            local initialProfile = mockStore:getProfile(player)
+            local initialMap = initialProfile.currentMap
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "volcanic_crater",
+                spawnId = "entrance",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+            expect(MapManager:GetPlayerMap(player)).to.equal(currentMap)
+            expect(mockStore:getProfile(player).currentMap).to.equal(initialMap)
+        end)
+
+        it("allows travel to volcanic crater spawns when requirements are met", function()
+            local player = createTestPlayer("VolcanicVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 35)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "volcanic_crater",
+                spawnId = "central_chamber",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("volcanic_crater")
+            expect(result.resolvedSpawn).to.equal("central_chamber")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("volcanic_crater", "central_chamber"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("volcanic_crater")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("volcanic_crater")
+            expect(spawnData.spawnName).to.equal("central_chamber")
         end)
 
         it("rejects travel to the frozen tundra when below the map requirement", function()
@@ -256,6 +307,7 @@ return function()
             expect(result).to.be.ok()
             expect(result.mapId).to.equal("frozen_tundra")
             expect(result.resolvedSpawn).to.equal("ridge")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("frozen_tundra", "ridge"))
 
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("frozen_tundra")


### PR DESCRIPTION
## Summary
- add a VolcanicCrater asset with crater platforms, lava flows, and resource shelves
- register the volcanic_crater map with spawns, travel restrictions, and expose spawn CFrames when validating travel
- extend map travel and manager specs to cover the new volcanic map

## Testing
- not run (roblox-cli unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca87046820832fbee4fbfbe68ca89c