### PR TITLE
Add champion arena map and matchmaking rules

### DIFF
--- a/Assets/Maps/ChampionArena.model.json
+++ b/Assets/Maps/ChampionArena.model.json
@@ -1,0 +1,96 @@
+{
+  "className": "Model",
+  "Name": "ChampionArena",
+  "NeedsPivotMigration": false,
+  "CentralPlatform": {
+    "className": "Part",
+    "Name": "CentralPlatform",
+    "Anchored": true,
+    "Size": [80, 2, 80],
+    "Position": [0, 1, 0]
+  },
+  "ArenaEmblem": {
+    "className": "Part",
+    "Name": "ArenaEmblem",
+    "Anchored": true,
+    "Size": [16, 1, 16],
+    "Position": [0, 2, 0]
+  },
+  "NorthStands": {
+    "className": "Part",
+    "Name": "NorthStands",
+    "Anchored": true,
+    "Size": [80, 16, 12],
+    "Position": [0, 8, -56]
+  },
+  "SouthStands": {
+    "className": "Part",
+    "Name": "SouthStands",
+    "Anchored": true,
+    "Size": [80, 16, 12],
+    "Position": [0, 8, 56]
+  },
+  "EastStands": {
+    "className": "Part",
+    "Name": "EastStands",
+    "Anchored": true,
+    "Size": [12, 16, 80],
+    "Position": [56, 8, 0]
+  },
+  "WestStands": {
+    "className": "Part",
+    "Name": "WestStands",
+    "Anchored": true,
+    "Size": [12, 16, 80],
+    "Position": [-56, 8, 0]
+  },
+  "VestibuleFloor": {
+    "className": "Part",
+    "Name": "VestibuleFloor",
+    "Anchored": true,
+    "Size": [26, 1, 20],
+    "Position": [-72, 0.5, 0]
+  },
+  "EastVestibuleFloor": {
+    "className": "Part",
+    "Name": "EastVestibuleFloor",
+    "Anchored": true,
+    "Size": [26, 1, 20],
+    "Position": [72, 0.5, 0]
+  },
+  "EntryPortalWest": {
+    "className": "Part",
+    "Name": "EntryPortalWest",
+    "Anchored": true,
+    "Size": [12, 16, 2],
+    "Position": [-80, 8, 0]
+  },
+  "EntryPortalEast": {
+    "className": "Part",
+    "Name": "EntryPortalEast",
+    "Anchored": true,
+    "Size": [12, 16, 2],
+    "Position": [80, 8, 0]
+  },
+  "PortalRampWest": {
+    "className": "Part",
+    "Name": "PortalRampWest",
+    "Anchored": true,
+    "Size": [16, 2, 12],
+    "Position": [-64, 1, 0]
+  },
+  "PortalRampEast": {
+    "className": "Part",
+    "Name": "PortalRampEast",
+    "Anchored": true,
+    "Size": [16, 2, 12],
+    "Position": [64, 1, 0]
+  },
+  "AnnouncerBooth": {
+    "className": "Part",
+    "Name": "AnnouncerBooth",
+    "Anchored": true,
+    "Size": [24, 12, 12],
+    "Position": [0, 10, 72]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Este repositório contém os scripts principais para um jogo estilo RPG no Roblo
 4. Sempre que houver alteração em dados persistentes, adicione uma nova migration.
 5. Teste as alterações localmente no Roblox Studio antes de publicar.
 
+## Eventos do Ato e Arena dos Campeões
+
+- A arena de desafios está disponível através do mapa `champion_arena`, definido em `ReplicatedStorage/MapConfig.lua` e exportado como `Assets/Maps/ChampionArena.model.json`.
+- Os jogadores devem cumprir o requisito mínimo de nível 25 para viajar para o vestiário e nível 30 para iniciar combates no ponto `arena_central`.
+- O PvP da arena exige que ambos os jogadores estejam com a missão `arena_campeoes` ativa e posicionados no spawn `arena_central`.
+- Utilize `MapManager:SpawnPlayer(player, "champion_arena", "vestiario")` ou envie um `Remotes.MapTravelRequest` correspondente para carregar o mapa durante eventos especiais do ato.
+- Interfaces de missão podem ler o campo `recommendedMap` das definições em `QuestConfig` para orientar os jogadores sobre quando se deslocar para a arena.
+
 ## Testes automatizados
 
 - O pacote `TestEZ` está disponível em `ReplicatedStorage/TestEZ` e é utilizado para executar as suites localizadas em `tests/server`.

--- a/ReplicatedStorage/MapConfig.lua
+++ b/ReplicatedStorage/MapConfig.lua
@@ -75,6 +75,34 @@ local MapConfig = {
             },
         },
     },
+
+    champion_arena = {
+        name = "Arena dos Campeões",
+        assetName = "ChampionArena",
+        defaultSpawn = "vestiario",
+        spawns = {
+            vestiario = CFrame.new(-72, 6, 0),
+            arena_central = CFrame.new(0, 6, 0),
+        },
+        travel = {
+            minLevel = 25,
+            allowedSpawns = { "vestiario", "arena_central" },
+            spawnRequirements = {
+                arena_central = {
+                    minLevel = 30,
+                },
+            },
+        },
+        matchmaking = {
+            pve = {
+                recommendedSpawns = { "arena_central" },
+            },
+            pvp = {
+                requiredQuest = "arena_campeoes",
+                allowedSpawns = { "arena_central" },
+            },
+        },
+    },
 }
 
 return MapConfig

--- a/ReplicatedStorage/quests/act2/arena_campeoes.lua
+++ b/ReplicatedStorage/quests/act2/arena_campeoes.lua
@@ -4,6 +4,12 @@ local quest = {
     questType = "main",
     name = "A Arena dos Campeões",
     description = "Prove sua força na arena enfrentando desafios alinhados à sua especialidade.",
+    recommendedMap = {
+        mapId = "champion_arena",
+        spawnId = "vestiario",
+        instructions = "Viaje até o vestiário da Arena dos Campeões e avance ao centro quando estiver pronto para lutar.",
+    },
+    matchmakingTag = "champion_arena",
     objective = {
         type = "story",
         target = "titulo_campeao",

--- a/ServerScriptService/Modules/MapManager.lua
+++ b/ServerScriptService/Modules/MapManager.lua
@@ -117,6 +117,11 @@ function MapManager:GetPlayerMap(player)
     return spawnData and spawnData.mapId or nil
 end
 
+function MapManager:GetPlayerSpawnName(player)
+    local spawnData = self.playerSpawns[player]
+    return spawnData and spawnData.spawnName or nil
+end
+
 function MapManager:Load(mapId)
     local config = getMapConfig(mapId)
     local maps = getMapsFolder()

--- a/ServerScriptService/Modules/QuestManager.lua
+++ b/ServerScriptService/Modules/QuestManager.lua
@@ -185,13 +185,27 @@ function QuestManager:AcceptQuest(questId)
         return false, "Limite de missões ativas atingido"
     end
 
-    self.data.active[questId] = {
+    local entry = {
         id = questId,
         progress = 0,
         goal = definition.objective.count or 1,
         status = "active",
         objective = definition.objective,
     }
+
+    if definition.recommendedMap ~= nil then
+        if typeof(definition.recommendedMap) == "table" then
+            entry.recommendedMap = table.clone(definition.recommendedMap)
+        else
+            entry.recommendedMap = definition.recommendedMap
+        end
+    end
+
+    if type(definition.matchmakingTag) == "string" and definition.matchmakingTag ~= "" then
+        entry.matchmakingTag = definition.matchmakingTag
+    end
+
+    self.data.active[questId] = entry
 
     self:_save()
     self:_pushUpdate()
@@ -322,6 +336,19 @@ function QuestManager:RegisterCollection(target, amount)
             self:UpdateProgress(questId, progressAmount)
         end
     end
+end
+
+function QuestManager:IsQuestActive(questId)
+    if type(questId) ~= "string" or questId == "" then
+        return false
+    end
+
+    local active = self.data.active
+    if type(active) ~= "table" then
+        return false
+    end
+
+    return active[questId] ~= nil
 end
 
 function QuestManager:Destroy()

--- a/tests/server/CombatRequest.spec.lua
+++ b/tests/server/CombatRequest.spec.lua
@@ -1,0 +1,175 @@
+return function()
+    local Workspace = game:GetService("Workspace")
+    local ReplicatedStorage = game:GetService("ReplicatedStorage")
+    local ServerScriptService = game:GetService("ServerScriptService")
+
+    local MapManager = require(ServerScriptService:WaitForChild("Modules"):WaitForChild("MapManager"))
+    local MapConfig = require(ReplicatedStorage:WaitForChild("MapConfig"))
+
+    local MockProfileStore = require(script.Parent.Parent.utils.MockProfileStore)
+    local TestPlayers = require(script.Parent.Parent.utils.TestPlayers)
+
+    local mapAssetNames = {}
+    for _, config in pairs(MapConfig) do
+        if type(config) == "table" then
+            local assetName = config.assetName
+            if type(assetName) == "string" then
+                mapAssetNames[assetName] = true
+            end
+        end
+    end
+
+    local function destroyMapInstances()
+        for _, instance in ipairs(Workspace:GetChildren()) do
+            if instance:IsA("Model") and mapAssetNames[instance.Name] then
+                instance:Destroy()
+            end
+        end
+    end
+
+    describe("CombatRequest matchmaking", function()
+        local mockStore
+        local controllers
+        local createdPlayers
+
+        local function createTestPlayer(name)
+            local player = TestPlayers.create(name)
+            table.insert(createdPlayers, player)
+            task.wait()
+            return player
+        end
+
+        local function cleanupPlayers()
+            if not createdPlayers then
+                return
+            end
+
+            for index = #createdPlayers, 1, -1 do
+                local player = createdPlayers[index]
+                TestPlayers.destroy(player)
+            end
+            createdPlayers = {}
+            task.wait()
+        end
+
+        local function setPlayerLevel(player, level)
+            local controller = controllers[player]
+            if controller and controller.stats and controller.stats.stats then
+                controller.stats.stats.level = level
+            end
+
+            local profile = mockStore:getProfile(player)
+            if profile and profile.stats then
+                profile.stats.level = level
+            end
+        end
+
+        local function acceptArenaQuest(player)
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+            local quests = controller.quests
+            expect(quests).to.be.ok()
+            local accepted, reason = quests:AcceptQuest("arena_campeoes")
+            if not accepted and reason == "Missão já aceita ou concluída" then
+                return
+            end
+            expect(accepted).to.equal(true)
+        end
+
+        beforeAll(function()
+            mockStore = MockProfileStore.new()
+            controllers = require(ServerScriptService:WaitForChild("Main"))
+            createdPlayers = {}
+        end)
+
+        afterAll(function()
+            cleanupPlayers()
+            destroyMapInstances()
+            MapManager:Unload()
+            mockStore:restore()
+        end)
+
+        beforeEach(function()
+            createdPlayers = {}
+            mockStore:reset()
+            destroyMapInstances()
+            MapManager:Unload()
+        end)
+
+        afterEach(function()
+            cleanupPlayers()
+            destroyMapInstances()
+            MapManager:Unload()
+        end)
+
+        it("blocks PvP when players are in different maps", function()
+            local attacker = createTestPlayer("ArenaDifferentA")
+            local defender = createTestPlayer("ArenaDifferentB")
+
+            setPlayerLevel(attacker, 32)
+            setPlayerLevel(defender, 32)
+
+            MapManager:SpawnPlayer(attacker, "starter_village")
+            MapManager:SpawnPlayer(defender, "champion_arena", "vestiario")
+
+            local ok, target, weapon, reason = controllers._validateCombatRequest(attacker, defender, nil)
+            expect(ok).to.equal(false)
+            expect(reason).to.equal("jogadores em mapas diferentes")
+            expect(target).to.equal(nil)
+            expect(weapon).to.equal(nil)
+        end)
+
+        it("enforces quest requirement for champion arena PvP", function()
+            local attacker = createTestPlayer("ArenaNoQuestA")
+            local defender = createTestPlayer("ArenaNoQuestB")
+
+            setPlayerLevel(attacker, 34)
+            setPlayerLevel(defender, 34)
+
+            MapManager:SpawnPlayer(attacker, "champion_arena", "arena_central")
+            MapManager:SpawnPlayer(defender, "champion_arena", "arena_central")
+
+            local ok, _, _, reason = controllers._validateCombatRequest(attacker, defender, nil)
+            expect(ok).to.equal(false)
+            expect(reason).to.equal("requisitos de matchmaking não atendidos")
+        end)
+
+        it("blocks champion arena PvP outside the allowed spawn", function()
+            local attacker = createTestPlayer("ArenaSpawnA")
+            local defender = createTestPlayer("ArenaSpawnB")
+
+            setPlayerLevel(attacker, 35)
+            setPlayerLevel(defender, 35)
+
+            acceptArenaQuest(attacker)
+            acceptArenaQuest(defender)
+
+            MapManager:SpawnPlayer(attacker, "champion_arena", "vestiario")
+            MapManager:SpawnPlayer(defender, "champion_arena", "vestiario")
+
+            local ok, _, _, reason = controllers._validateCombatRequest(attacker, defender, nil)
+            expect(ok).to.equal(false)
+            expect(reason).to.equal("pvp restrito a spawns específicos")
+        end)
+
+        it("allows champion arena PvP when all requirements are satisfied", function()
+            local attacker = createTestPlayer("ArenaReadyA")
+            local defender = createTestPlayer("ArenaReadyB")
+
+            setPlayerLevel(attacker, 36)
+            setPlayerLevel(defender, 36)
+
+            acceptArenaQuest(attacker)
+            acceptArenaQuest(defender)
+
+            MapManager:SpawnPlayer(attacker, "champion_arena", "arena_central")
+            MapManager:SpawnPlayer(defender, "champion_arena", "arena_central")
+
+            local ok, target, weapon, reason = controllers._validateCombatRequest(attacker, defender, nil)
+            expect(ok).to.equal(true)
+            expect(target).to.equal(defender)
+            expect(weapon).to.equal(nil)
+            expect(reason).to.equal(nil)
+        end)
+    end)
+end

--- a/tests/server/MapManager.spec.lua
+++ b/tests/server/MapManager.spec.lua
@@ -68,6 +68,16 @@ return function()
             expect(MapManager:GetCurrentMapId()).to.equal("desert_outpost")
         end)
 
+        it("loads the champion arena map with its configured spawns", function()
+            local arenaModel = MapManager:Load("champion_arena")
+            expect(arenaModel.Parent).to.equal(Workspace)
+            expect(arenaModel.Name).to.equal("ChampionArena")
+            expect(MapManager:GetCurrentMapId()).to.equal("champion_arena")
+
+            local centralSpawn = MapManager:GetSpawnCFrame("champion_arena", "arena_central")
+            expect(centralSpawn).to.equal(CFrame.new(0, 6, 0))
+        end)
+
         it("spawns players at the configured positions", function()
             local spawnCFrame = MapManager:GetSpawnCFrame("starter_village", "blacksmith")
             MapManager:SpawnPlayer(player, "starter_village", "blacksmith")

--- a/tests/server/MapTravelRequest.spec.lua
+++ b/tests/server/MapTravelRequest.spec.lua
@@ -114,10 +114,8 @@ return function()
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("crystal_cavern")
 
-            local spawnData = MapManager.playerSpawns[player]
-            expect(spawnData).to.be.ok()
-            expect(spawnData.mapId).to.equal("crystal_cavern")
-            expect(spawnData.spawnName).to.equal("sanctuary")
+            expect(MapManager:GetPlayerMap(player)).to.equal("crystal_cavern")
+            expect(MapManager:GetPlayerSpawnName(player)).to.equal("sanctuary")
         end)
 
         it("rejects travel for unknown maps", function()
@@ -196,10 +194,8 @@ return function()
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("desert_outpost")
 
-            local spawnData = MapManager.playerSpawns[player]
-            expect(spawnData).to.be.ok()
-            expect(spawnData.mapId).to.equal("desert_outpost")
-            expect(spawnData.spawnName).to.equal("camp")
+            expect(MapManager:GetPlayerMap(player)).to.equal("desert_outpost")
+            expect(MapManager:GetPlayerSpawnName(player)).to.equal("camp")
         end)
 
         it("rejects travel to restricted desert outpost spawns when below the requirement", function()
@@ -216,6 +212,62 @@ return function()
 
             expect(success).to.equal(false)
             expect(reason).to.equal("nível insuficiente para o spawn")
+        end)
+
+        it("rejects travel to the champion arena when below the map requirement", function()
+            local player = createTestPlayer("ArenaLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 24)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "champion_arena",
+                spawnId = "vestiario",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("rejects travel to the champion arena central spawn when requirements are not met", function()
+            local player = createTestPlayer("ArenaCentralLocked")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 28)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "champion_arena",
+                spawnId = "arena_central",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente para o spawn")
+        end)
+
+        it("allows travel to the champion arena when requirements are satisfied", function()
+            local player = createTestPlayer("ArenaTraveler")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 32)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "champion_arena",
+                spawnId = "arena_central",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("champion_arena")
+            expect(result.resolvedSpawn).to.equal("arena_central")
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("champion_arena")
+
+            expect(MapManager:GetPlayerMap(player)).to.equal("champion_arena")
+            expect(MapManager:GetPlayerSpawnName(player)).to.equal("arena_central")
         end)
 
         it("rejects travel to the frozen tundra when below the map requirement", function()
@@ -260,10 +312,8 @@ return function()
             local profile = mockStore:getProfile(player)
             expect(profile.currentMap).to.equal("frozen_tundra")
 
-            local spawnData = MapManager.playerSpawns[player]
-            expect(spawnData).to.be.ok()
-            expect(spawnData.mapId).to.equal("frozen_tundra")
-            expect(spawnData.spawnName).to.equal("ridge")
+            expect(MapManager:GetPlayerMap(player)).to.equal("frozen_tundra")
+            expect(MapManager:GetPlayerSpawnName(player)).to.equal("ridge")
         end)
     end)
 end


### PR DESCRIPTION
## Summary
- add a Champion Arena map asset with stands, entry portals, and travel data in MapConfig
- enforce Champion Arena PvP requirements via combat validation and quest metadata updates
- expand tests for arena travel and matchmaking plus document how to load the arena during act events

## Testing
- not run (roblox-cli unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca8935ef90832f9d2da3371c17bf93