### PR TITLE
Remove redundant map model name properties

### DIFF
--- a/Assets/Maps/DesertOutpost.model.json
+++ b/Assets/Maps/DesertOutpost.model.json
@@ -1,6 +1,5 @@
 {
   "className": "Model",
-  "Name": "DesertOutpost",
   "NeedsPivotMigration": false,
   "SandFloor": {
     "className": "Part",

--- a/Assets/Maps/FrozenTundra.model.json
+++ b/Assets/Maps/FrozenTundra.model.json
@@ -1,6 +1,5 @@
 {
   "className": "Model",
-  "Name": "FrozenTundra",
   "NeedsPivotMigration": false,
   "SnowField": {
     "className": "Part",

--- a/Assets/Maps/VolcanicCrater.model.json
+++ b/Assets/Maps/VolcanicCrater.model.json
@@ -1,6 +1,5 @@
 {
   "className": "Model",
-  "Name": "VolcanicCrater",
   "NeedsPivotMigration": false,
   "CraterBase": {
     "className": "Part",


### PR DESCRIPTION
## Summary
- remove redundant root Name properties from DesertOutpost, FrozenTundra, and VolcanicCrater map models so Rojo defers to file names

## Testing
- `rojo build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8ef2d810832fac2a4bb840d984f7