### PR TITLE
Adjust observation spire spawn position

### DIFF
--- a/ReplicatedStorage/MapConfig.lua
+++ b/ReplicatedStorage/MapConfig.lua
@@ -83,7 +83,7 @@ local MapConfig = {
         spawns = {
             entrance = CFrame.new(0, 9, 72),
             central_chamber = CFrame.new(0, 10, 0),
-            observation_spire = CFrame.new(96, 10, 18),
+            observation_spire = CFrame.new(102, 10, 18),
         },
         travel = {
             minLevel = 26,


### PR DESCRIPTION
## Summary
- move the Volcanic Crater observation spire spawn to the outer platform so players no longer spawn inside the pillar

## Testing
- not run (roblox-cli not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca9464a0ec832f960c2a29d055082c