### PR TITLE
Add new act maps and travel coverage

### DIFF
--- a/Assets/Maps/AncientForest.model.json
+++ b/Assets/Maps/AncientForest.model.json
@@ -1,0 +1,74 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "ForestFloor": {
+    "className": "Part",
+    "Name": "ForestFloor",
+    "Anchored": true,
+    "Size": [280, 4, 280],
+    "Position": [0, -2, 0]
+  },
+  "ForestEdge": {
+    "className": "Part",
+    "Name": "ForestEdge",
+    "Anchored": true,
+    "Size": [140, 6, 80],
+    "Position": [0, 4, -100]
+  },
+  "RitualGlade": {
+    "className": "Part",
+    "Name": "RitualGlade",
+    "Anchored": true,
+    "Size": [120, 4, 120],
+    "Position": [0, 6, 0]
+  },
+  "CorruptedHeart": {
+    "className": "Part",
+    "Name": "CorruptedHeart",
+    "Anchored": true,
+    "Size": [80, 8, 80],
+    "Position": [0, 10, 96]
+  },
+  "TotemRingEast": {
+    "className": "Part",
+    "Name": "TotemRingEast",
+    "Anchored": true,
+    "Size": [20, 16, 20],
+    "Position": [60, 14, 0]
+  },
+  "TotemRingWest": {
+    "className": "Part",
+    "Name": "TotemRingWest",
+    "Anchored": true,
+    "Size": [20, 16, 20],
+    "Position": [-60, 14, -10]
+  },
+  "AncientBridge": {
+    "className": "Part",
+    "Name": "AncientBridge",
+    "Anchored": true,
+    "Size": [40, 4, 100],
+    "Position": [0, 5, -140]
+  },
+  "TreeClusterNorth": {
+    "className": "Part",
+    "Name": "TreeClusterNorth",
+    "Anchored": true,
+    "Size": [24, 24, 24],
+    "Position": [-90, 20, 60]
+  },
+  "TreeClusterSouth": {
+    "className": "Part",
+    "Name": "TreeClusterSouth",
+    "Anchored": true,
+    "Size": [24, 24, 24],
+    "Position": [90, 22, -40]
+  },
+  "RitualObelisk": {
+    "className": "Part",
+    "Name": "RitualObelisk",
+    "Anchored": true,
+    "Size": [12, 28, 12],
+    "Position": [0, 18, 30]
+  }
+}

--- a/Assets/Maps/DarkLordSanctum.model.json
+++ b/Assets/Maps/DarkLordSanctum.model.json
@@ -1,0 +1,67 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "SanctumFloor": {
+    "className": "Part",
+    "Name": "SanctumFloor",
+    "Anchored": true,
+    "Size": [260, 6, 260],
+    "Position": [0, -3, 0]
+  },
+  "OuterRing": {
+    "className": "Part",
+    "Name": "OuterRing",
+    "Anchored": true,
+    "Size": [200, 4, 200],
+    "Position": [0, 5, -40]
+  },
+  "ShadowFissure": {
+    "className": "Part",
+    "Name": "ShadowFissure",
+    "Anchored": true,
+    "Size": [80, 2, 80],
+    "Position": [0, 2, 0]
+  },
+  "ThronePlatform": {
+    "className": "Part",
+    "Name": "ThronePlatform",
+    "Anchored": true,
+    "Size": [60, 8, 60],
+    "Position": [0, 14, 80]
+  },
+  "EnergyPillarEast": {
+    "className": "Part",
+    "Name": "EnergyPillarEast",
+    "Anchored": true,
+    "Size": [16, 30, 16],
+    "Position": [70, 18, 0]
+  },
+  "EnergyPillarWest": {
+    "className": "Part",
+    "Name": "EnergyPillarWest",
+    "Anchored": true,
+    "Size": [16, 30, 16],
+    "Position": [-70, 18, 0]
+  },
+  "ShadowOverlook": {
+    "className": "Part",
+    "Name": "ShadowOverlook",
+    "Anchored": true,
+    "Size": [80, 6, 40],
+    "Position": [100, 10, 0]
+  },
+  "EntranceBridge": {
+    "className": "Part",
+    "Name": "EntranceBridge",
+    "Anchored": true,
+    "Size": [40, 4, 120],
+    "Position": [0, 6, -140]
+  },
+  "SealingRunes": {
+    "className": "Part",
+    "Name": "SealingRunes",
+    "Anchored": true,
+    "Size": [120, 2, 120],
+    "Position": [0, 4, 40]
+  }
+}

--- a/Assets/Maps/LegendaryForge.model.json
+++ b/Assets/Maps/LegendaryForge.model.json
@@ -1,0 +1,67 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "MountainBase": {
+    "className": "Part",
+    "Name": "MountainBase",
+    "Anchored": true,
+    "Size": [280, 8, 280],
+    "Position": [0, -4, 0]
+  },
+  "EntranceBridge": {
+    "className": "Part",
+    "Name": "EntranceBridge",
+    "Anchored": true,
+    "Size": [40, 4, 120],
+    "Position": [0, 6, -120]
+  },
+  "ForgeChamber": {
+    "className": "Part",
+    "Name": "ForgeChamber",
+    "Anchored": true,
+    "Size": [120, 10, 120],
+    "Position": [0, 8, 0]
+  },
+  "ForgeHeart": {
+    "className": "Part",
+    "Name": "ForgeHeart",
+    "Anchored": true,
+    "Size": [40, 10, 40],
+    "Position": [0, 12, 0]
+  },
+  "SmelterHall": {
+    "className": "Part",
+    "Name": "SmelterHall",
+    "Anchored": true,
+    "Size": [80, 10, 60],
+    "Position": [-70, 10, 20]
+  },
+  "AncestralAnvil": {
+    "className": "Part",
+    "Name": "AncestralAnvil",
+    "Anchored": true,
+    "Size": [24, 6, 24],
+    "Position": [0, 9, 20]
+  },
+  "Balcony": {
+    "className": "Part",
+    "Name": "Balcony",
+    "Anchored": true,
+    "Size": [60, 6, 40],
+    "Position": [80, 14, 0]
+  },
+  "CoolingPool": {
+    "className": "Part",
+    "Name": "CoolingPool",
+    "Anchored": true,
+    "Size": [50, 4, 50],
+    "Position": [0, 6, 80]
+  },
+  "MountainPeak": {
+    "className": "Part",
+    "Name": "MountainPeak",
+    "Anchored": true,
+    "Size": [180, 6, 180],
+    "Position": [0, 20, 0]
+  }
+}

--- a/Assets/Maps/RoyalCastle.model.json
+++ b/Assets/Maps/RoyalCastle.model.json
@@ -1,0 +1,74 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "CastleGround": {
+    "className": "Part",
+    "Name": "CastleGround",
+    "Anchored": true,
+    "Size": [260, 4, 260],
+    "Position": [0, -4, 0]
+  },
+  "OuterCourtyard": {
+    "className": "Part",
+    "Name": "OuterCourtyard",
+    "Anchored": true,
+    "Size": [160, 2, 140],
+    "Position": [0, 4, -60]
+  },
+  "GrandHall": {
+    "className": "Part",
+    "Name": "GrandHall",
+    "Anchored": true,
+    "Size": [80, 10, 60],
+    "Position": [0, 10, 10]
+  },
+  "ThroneDais": {
+    "className": "Part",
+    "Name": "ThroneDais",
+    "Anchored": true,
+    "Size": [36, 6, 24],
+    "Position": [0, 12, 28]
+  },
+  "DungeonCells": {
+    "className": "Part",
+    "Name": "DungeonCells",
+    "Anchored": true,
+    "Size": [60, 6, 80],
+    "Position": [0, 6, 86]
+  },
+  "LibraryWing": {
+    "className": "Part",
+    "Name": "LibraryWing",
+    "Anchored": true,
+    "Size": [50, 10, 40],
+    "Position": [-70, 8, 6]
+  },
+  "Barracks": {
+    "className": "Part",
+    "Name": "Barracks",
+    "Anchored": true,
+    "Size": [50, 10, 40],
+    "Position": [70, 8, -4]
+  },
+  "GateBridge": {
+    "className": "Part",
+    "Name": "GateBridge",
+    "Anchored": true,
+    "Size": [32, 4, 80],
+    "Position": [0, 6, -120]
+  },
+  "WatchTowerNorth": {
+    "className": "Part",
+    "Name": "WatchTowerNorth",
+    "Anchored": true,
+    "Size": [18, 24, 18],
+    "Position": [-110, 18, -90]
+  },
+  "WatchTowerSouth": {
+    "className": "Part",
+    "Name": "WatchTowerSouth",
+    "Anchored": true,
+    "Size": [18, 24, 18],
+    "Position": [110, 18, -90]
+  }
+}

--- a/Assets/Maps/ShadowDragonLair.model.json
+++ b/Assets/Maps/ShadowDragonLair.model.json
@@ -1,0 +1,67 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "LairCavern": {
+    "className": "Part",
+    "Name": "LairCavern",
+    "Anchored": true,
+    "Size": [320, 6, 320],
+    "Position": [0, -3, 0]
+  },
+  "EntrancePath": {
+    "className": "Part",
+    "Name": "EntrancePath",
+    "Anchored": true,
+    "Size": [60, 4, 120],
+    "Position": [0, 4, 140]
+  },
+  "LavaPool": {
+    "className": "Part",
+    "Name": "LavaPool",
+    "Anchored": true,
+    "Size": [120, 4, 120],
+    "Position": [0, 2, 0]
+  },
+  "DragonPerch": {
+    "className": "Part",
+    "Name": "DragonPerch",
+    "Anchored": true,
+    "Size": [80, 6, 80],
+    "Position": [0, 10, -80]
+  },
+  "TreasureHoard": {
+    "className": "Part",
+    "Name": "TreasureHoard",
+    "Anchored": true,
+    "Size": [100, 6, 60],
+    "Position": [0, 8, -140]
+  },
+  "SidePlatformEast": {
+    "className": "Part",
+    "Name": "SidePlatformEast",
+    "Anchored": true,
+    "Size": [40, 6, 80],
+    "Position": [100, 8, -40]
+  },
+  "SidePlatformWest": {
+    "className": "Part",
+    "Name": "SidePlatformWest",
+    "Anchored": true,
+    "Size": [40, 6, 80],
+    "Position": [-100, 8, -20]
+  },
+  "CrystalCluster": {
+    "className": "Part",
+    "Name": "CrystalCluster",
+    "Anchored": true,
+    "Size": [24, 24, 24],
+    "Position": [60, 20, 40]
+  },
+  "CollapsedColumn": {
+    "className": "Part",
+    "Name": "CollapsedColumn",
+    "Anchored": true,
+    "Size": [12, 24, 60],
+    "Position": [-60, 18, 60]
+  }
+}

--- a/Assets/Maps/SiegedCity.model.json
+++ b/Assets/Maps/SiegedCity.model.json
@@ -1,0 +1,74 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "CityGround": {
+    "className": "Part",
+    "Name": "CityGround",
+    "Anchored": true,
+    "Size": [300, 4, 300],
+    "Position": [0, -2, 0]
+  },
+  "CityWallNorth": {
+    "className": "Part",
+    "Name": "CityWallNorth",
+    "Anchored": true,
+    "Size": [300, 20, 12],
+    "Position": [0, 10, -120]
+  },
+  "CityWallSouth": {
+    "className": "Part",
+    "Name": "CityWallSouth",
+    "Anchored": true,
+    "Size": [300, 20, 12],
+    "Position": [0, 10, 120]
+  },
+  "GateHouse": {
+    "className": "Part",
+    "Name": "GateHouse",
+    "Anchored": true,
+    "Size": [80, 20, 40],
+    "Position": [0, 12, -110]
+  },
+  "InnerCourtyard": {
+    "className": "Part",
+    "Name": "InnerCourtyard",
+    "Anchored": true,
+    "Size": [120, 4, 120],
+    "Position": [0, 4, 40]
+  },
+  "BattlementWalk": {
+    "className": "Part",
+    "Name": "BattlementWalk",
+    "Anchored": true,
+    "Size": [120, 6, 30],
+    "Position": [70, 12, -20]
+  },
+  "DefenseTowerEast": {
+    "className": "Part",
+    "Name": "DefenseTowerEast",
+    "Anchored": true,
+    "Size": [18, 28, 18],
+    "Position": [120, 18, 0]
+  },
+  "DefenseTowerWest": {
+    "className": "Part",
+    "Name": "DefenseTowerWest",
+    "Anchored": true,
+    "Size": [18, 28, 18],
+    "Position": [-120, 18, 0]
+  },
+  "SupplyDepot": {
+    "className": "Part",
+    "Name": "SupplyDepot",
+    "Anchored": true,
+    "Size": [40, 10, 30],
+    "Position": [-60, 8, 50]
+  },
+  "MarketSquare": {
+    "className": "Part",
+    "Name": "MarketSquare",
+    "Anchored": true,
+    "Size": [80, 4, 80],
+    "Position": [0, 4, 100]
+  }
+}

--- a/Assets/Maps/SkyTower.model.json
+++ b/Assets/Maps/SkyTower.model.json
@@ -1,0 +1,67 @@
+{
+  "className": "Model",
+  "NeedsPivotMigration": false,
+  "BasePlatform": {
+    "className": "Part",
+    "Name": "BasePlatform",
+    "Anchored": true,
+    "Size": [80, 2, 80],
+    "Position": [0, 1, 0]
+  },
+  "SupportColumn": {
+    "className": "Part",
+    "Name": "SupportColumn",
+    "Anchored": true,
+    "Size": [20, 60, 20],
+    "Position": [0, 30, 0]
+  },
+  "MidPlatform": {
+    "className": "Part",
+    "Name": "MidPlatform",
+    "Anchored": true,
+    "Size": [60, 2, 60],
+    "Position": [0, 61, 0]
+  },
+  "UpperColumn": {
+    "className": "Part",
+    "Name": "UpperColumn",
+    "Anchored": true,
+    "Size": [16, 40, 16],
+    "Position": [0, 80, 0]
+  },
+  "ApexPlatform": {
+    "className": "Part",
+    "Name": "ApexPlatform",
+    "Anchored": true,
+    "Size": [50, 2, 50],
+    "Position": [0, 101, 0]
+  },
+  "FloatingRingEast": {
+    "className": "Part",
+    "Name": "FloatingRingEast",
+    "Anchored": true,
+    "Size": [24, 4, 60],
+    "Position": [46, 61, 0]
+  },
+  "FloatingRingWest": {
+    "className": "Part",
+    "Name": "FloatingRingWest",
+    "Anchored": true,
+    "Size": [24, 4, 60],
+    "Position": [-46, 61, 0]
+  },
+  "LiftBridge": {
+    "className": "Part",
+    "Name": "LiftBridge",
+    "Anchored": true,
+    "Size": [18, 2, 60],
+    "Position": [0, 31, -60]
+  },
+  "ObservationDeck": {
+    "className": "Part",
+    "Name": "ObservationDeck",
+    "Anchored": true,
+    "Size": [40, 2, 40],
+    "Position": [0, 141, 0]
+  }
+}

--- a/ReplicatedStorage/MapConfig.lua
+++ b/ReplicatedStorage/MapConfig.lua
@@ -121,6 +121,167 @@ local MapConfig = {
             },
         },
     },
+
+    royal_castle = {
+        name = "Castelo Real",
+        assetName = "RoyalCastle",
+        defaultSpawn = "courtyard",
+        spawns = {
+            courtyard = CFrame.new(0, 6, -80),
+            grand_hall = CFrame.new(0, 12, 20),
+            dungeon_cells = CFrame.new(0, 8, 86),
+        },
+        travel = {
+            minLevel = 45,
+            allowedSpawns = { "courtyard", "grand_hall", "dungeon_cells" },
+            spawnRequirements = {
+                grand_hall = {
+                    minLevel = 49,
+                },
+                dungeon_cells = {
+                    minLevel = 51,
+                },
+            },
+        },
+    },
+
+    ancient_forest = {
+        name = "Floresta Ancestral Corrompida",
+        assetName = "AncientForest",
+        defaultSpawn = "forest_edge",
+        spawns = {
+            forest_edge = CFrame.new(0, 6, -120),
+            ritual_glade = CFrame.new(0, 7, 0),
+            corrupted_heart = CFrame.new(0, 8, 96),
+        },
+        travel = {
+            minLevel = 50,
+            allowedSpawns = { "forest_edge", "ritual_glade", "corrupted_heart" },
+            spawnRequirements = {
+                ritual_glade = {
+                    minLevel = 55,
+                },
+                corrupted_heart = {
+                    minLevel = 57,
+                },
+            },
+        },
+    },
+
+    sky_tower = {
+        name = "Torre dos Céus",
+        assetName = "SkyTower",
+        defaultSpawn = "tower_base",
+        spawns = {
+            tower_base = CFrame.new(0, 6, 0),
+            mid_spire = CFrame.new(0, 62, 0),
+            apex_platform = CFrame.new(0, 102, 0),
+        },
+        travel = {
+            minLevel = 56,
+            allowedSpawns = { "tower_base", "mid_spire", "apex_platform" },
+            spawnRequirements = {
+                mid_spire = {
+                    minLevel = 60,
+                },
+                apex_platform = {
+                    minLevel = 62,
+                },
+            },
+        },
+    },
+
+    sieged_city = {
+        name = "Cidade Sitiada",
+        assetName = "SiegedCity",
+        defaultSpawn = "front_gate",
+        spawns = {
+            front_gate = CFrame.new(0, 8, -120),
+            battlement_wall = CFrame.new(70, 14, -20),
+            inner_courtyard = CFrame.new(0, 6, 40),
+        },
+        travel = {
+            minLevel = 62,
+            allowedSpawns = { "front_gate", "battlement_wall", "inner_courtyard" },
+            spawnRequirements = {
+                battlement_wall = {
+                    minLevel = 66,
+                },
+                inner_courtyard = {
+                    minLevel = 68,
+                },
+            },
+        },
+    },
+
+    shadow_dragon_lair = {
+        name = "Covil do Dragão Sombrio",
+        assetName = "ShadowDragonLair",
+        defaultSpawn = "lair_entrance",
+        spawns = {
+            lair_entrance = CFrame.new(0, 6, 140),
+            lava_pit = CFrame.new(0, 4, 0),
+            hoard_vault = CFrame.new(0, 10, -140),
+        },
+        travel = {
+            minLevel = 68,
+            allowedSpawns = { "lair_entrance", "lava_pit", "hoard_vault" },
+            spawnRequirements = {
+                lava_pit = {
+                    minLevel = 72,
+                },
+                hoard_vault = {
+                    minLevel = 74,
+                },
+            },
+        },
+    },
+
+    legendary_forge = {
+        name = "Forja Lendária",
+        assetName = "LegendaryForge",
+        defaultSpawn = "entrance_chamber",
+        spawns = {
+            entrance_chamber = CFrame.new(0, 6, -120),
+            forge_heart = CFrame.new(0, 12, 0),
+            summit_balcony = CFrame.new(80, 16, 0),
+        },
+        travel = {
+            minLevel = 74,
+            allowedSpawns = { "entrance_chamber", "forge_heart", "summit_balcony" },
+            spawnRequirements = {
+                forge_heart = {
+                    minLevel = 78,
+                },
+                summit_balcony = {
+                    minLevel = 80,
+                },
+            },
+        },
+    },
+
+    dark_lord_sanctum = {
+        name = "Santuário do Lorde Sombrio",
+        assetName = "DarkLordSanctum",
+        defaultSpawn = "outer_ring",
+        spawns = {
+            outer_ring = CFrame.new(0, 6, -120),
+            throne_dais = CFrame.new(0, 14, 80),
+            shadow_overlook = CFrame.new(100, 10, 0),
+        },
+        travel = {
+            minLevel = 80,
+            allowedSpawns = { "outer_ring", "throne_dais", "shadow_overlook" },
+            spawnRequirements = {
+                throne_dais = {
+                    minLevel = 84,
+                },
+                shadow_overlook = {
+                    minLevel = 86,
+                },
+            },
+        },
+    },
 }
 
 return MapConfig

--- a/tests/server/MapManager.spec.lua
+++ b/tests/server/MapManager.spec.lua
@@ -85,6 +85,60 @@ return function()
             expect(spawnCFrame).to.equal(MapConfig.champion_arena.spawns.champion_podium)
         end)
 
+        local extendedMapCases = {
+            {
+                mapId = "royal_castle",
+                assetName = "RoyalCastle",
+                spawnId = "grand_hall",
+            },
+            {
+                mapId = "ancient_forest",
+                assetName = "AncientForest",
+                spawnId = "corrupted_heart",
+            },
+            {
+                mapId = "sky_tower",
+                assetName = "SkyTower",
+                spawnId = "apex_platform",
+            },
+            {
+                mapId = "sieged_city",
+                assetName = "SiegedCity",
+                spawnId = "inner_courtyard",
+            },
+            {
+                mapId = "shadow_dragon_lair",
+                assetName = "ShadowDragonLair",
+                spawnId = "hoard_vault",
+            },
+            {
+                mapId = "legendary_forge",
+                assetName = "LegendaryForge",
+                spawnId = "forge_heart",
+            },
+            {
+                mapId = "dark_lord_sanctum",
+                assetName = "DarkLordSanctum",
+                spawnId = "throne_dais",
+            },
+        }
+
+        for _, case in ipairs(extendedMapCases) do
+            it(string.format("loads the %s map and resolves the %s spawn", case.mapId, case.spawnId), function()
+                local mapId = case.mapId
+                local assetName = case.assetName
+                local spawnId = case.spawnId
+
+                local mapModel = MapManager:Load(mapId)
+                expect(mapModel.Parent).to.equal(Workspace)
+                expect(mapModel.Name).to.equal(assetName)
+                expect(MapManager:GetCurrentMapId()).to.equal(mapId)
+
+                local spawnCFrame = MapManager:GetSpawnCFrame(mapId, spawnId)
+                expect(spawnCFrame).to.equal(MapConfig[mapId].spawns[spawnId])
+            end)
+        end
+
         it("spawns players at the configured positions", function()
             local spawnCFrame = MapManager:GetSpawnCFrame("starter_village", "blacksmith")
             MapManager:SpawnPlayer(player, "starter_village", "blacksmith")

--- a/tests/server/MapTravelRequest.spec.lua
+++ b/tests/server/MapTravelRequest.spec.lua
@@ -334,6 +334,307 @@ return function()
             expect(spawnData.spawnName).to.equal("champion_podium")
         end)
 
+        it("rejects travel to the royal castle when below the map requirement", function()
+            local player = createTestPlayer("RoyalLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 43)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "royal_castle",
+                spawnId = "courtyard",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to royal castle spawns when requirements are met", function()
+            local player = createTestPlayer("RoyalVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 52)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "royal_castle",
+                spawnId = "grand_hall",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("royal_castle")
+            expect(result.resolvedSpawn).to.equal("grand_hall")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("royal_castle", "grand_hall"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("royal_castle")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("royal_castle")
+            expect(spawnData.spawnName).to.equal("grand_hall")
+        end)
+
+        it("rejects travel to the ancient forest when below the map requirement", function()
+            local player = createTestPlayer("ForestLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 48)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "ancient_forest",
+                spawnId = "forest_edge",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to ancient forest spawns when requirements are met", function()
+            local player = createTestPlayer("ForestVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 58)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "ancient_forest",
+                spawnId = "ritual_glade",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("ancient_forest")
+            expect(result.resolvedSpawn).to.equal("ritual_glade")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("ancient_forest", "ritual_glade"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("ancient_forest")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("ancient_forest")
+            expect(spawnData.spawnName).to.equal("ritual_glade")
+        end)
+
+        it("rejects travel to the sky tower when below the map requirement", function()
+            local player = createTestPlayer("SkyLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 54)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "sky_tower",
+                spawnId = "tower_base",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to sky tower spawns when requirements are met", function()
+            local player = createTestPlayer("SkyVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 64)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "sky_tower",
+                spawnId = "apex_platform",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("sky_tower")
+            expect(result.resolvedSpawn).to.equal("apex_platform")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("sky_tower", "apex_platform"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("sky_tower")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("sky_tower")
+            expect(spawnData.spawnName).to.equal("apex_platform")
+        end)
+
+        it("rejects travel to the sieged city when below the map requirement", function()
+            local player = createTestPlayer("SiegeLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 60)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "sieged_city",
+                spawnId = "front_gate",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to sieged city spawns when requirements are met", function()
+            local player = createTestPlayer("SiegeVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 70)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "sieged_city",
+                spawnId = "inner_courtyard",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("sieged_city")
+            expect(result.resolvedSpawn).to.equal("inner_courtyard")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("sieged_city", "inner_courtyard"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("sieged_city")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("sieged_city")
+            expect(spawnData.spawnName).to.equal("inner_courtyard")
+        end)
+
+        it("rejects travel to the shadow dragon lair when below the map requirement", function()
+            local player = createTestPlayer("LairLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 66)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "shadow_dragon_lair",
+                spawnId = "lair_entrance",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to shadow dragon lair spawns when requirements are met", function()
+            local player = createTestPlayer("LairVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 76)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "shadow_dragon_lair",
+                spawnId = "hoard_vault",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("shadow_dragon_lair")
+            expect(result.resolvedSpawn).to.equal("hoard_vault")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("shadow_dragon_lair", "hoard_vault"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("shadow_dragon_lair")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("shadow_dragon_lair")
+            expect(spawnData.spawnName).to.equal("hoard_vault")
+        end)
+
+        it("rejects travel to the legendary forge when below the map requirement", function()
+            local player = createTestPlayer("ForgeLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 72)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "legendary_forge",
+                spawnId = "entrance_chamber",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to legendary forge spawns when requirements are met", function()
+            local player = createTestPlayer("ForgeVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 80)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "legendary_forge",
+                spawnId = "forge_heart",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("legendary_forge")
+            expect(result.resolvedSpawn).to.equal("forge_heart")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("legendary_forge", "forge_heart"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("legendary_forge")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("legendary_forge")
+            expect(spawnData.spawnName).to.equal("forge_heart")
+        end)
+
+        it("rejects travel to the dark lord sanctum when below the map requirement", function()
+            local player = createTestPlayer("SanctumLowLevel")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 78)
+
+            local success, reason = controllers._handleMapTravelRequest(player, {
+                mapId = "dark_lord_sanctum",
+                spawnId = "outer_ring",
+            })
+
+            expect(success).to.equal(false)
+            expect(reason).to.equal("nível insuficiente")
+        end)
+
+        it("allows travel to dark lord sanctum spawns when requirements are met", function()
+            local player = createTestPlayer("SanctumVeteran")
+            local controller = controllers[player]
+            expect(controller).to.be.ok()
+
+            setPlayerLevel(player, 86)
+
+            local success, result = controllers._handleMapTravelRequest(player, {
+                mapId = "dark_lord_sanctum",
+                spawnId = "throne_dais",
+            })
+
+            expect(success).to.equal(true)
+            expect(result).to.be.ok()
+            expect(result.mapId).to.equal("dark_lord_sanctum")
+            expect(result.resolvedSpawn).to.equal("throne_dais")
+            expect(result.resolvedSpawnCFrame).to.equal(MapManager:GetSpawnCFrame("dark_lord_sanctum", "throne_dais"))
+
+            local profile = mockStore:getProfile(player)
+            expect(profile.currentMap).to.equal("dark_lord_sanctum")
+
+            local spawnData = MapManager.playerSpawns[player]
+            expect(spawnData).to.be.ok()
+            expect(spawnData.mapId).to.equal("dark_lord_sanctum")
+            expect(spawnData.spawnName).to.equal("throne_dais")
+        end)
+
         it("rejects travel to the frozen tundra when below the map requirement", function()
             local player = createTestPlayer("FrozenLowLevel")
             local controller = controllers[player]


### PR DESCRIPTION
## Summary
- add placeholder map models for the remaining Act 3 to Act 5 locations
- extend `MapConfig` with the new map ids, spawn points and travel requirements
- broaden MapManager and map travel tests to exercise every new destination

## Testing
- not run (roblox-cli not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca80490908832f8ca5d14c7a67ed11