### PR TITLE
Ensure map assets are named and pivot migrated

### DIFF
--- a/Assets/Maps/AncientForest.model.json
+++ b/Assets/Maps/AncientForest.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "AncientForest",
   "NeedsPivotMigration": false,
   "ForestFloor": {
     "className": "Part",

--- a/Assets/Maps/ChampionArena.model.json
+++ b/Assets/Maps/ChampionArena.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "ChampionArena",
   "NeedsPivotMigration": false,
   "ArenaFloor": {
     "className": "Part",

--- a/Assets/Maps/CrystalCavern.model.json
+++ b/Assets/Maps/CrystalCavern.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "CrystalCavern",
   "NeedsPivotMigration": false,
   "Floor": {
     "className": "Part",

--- a/Assets/Maps/DarkLordSanctum.model.json
+++ b/Assets/Maps/DarkLordSanctum.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "DarkLordSanctum",
   "NeedsPivotMigration": false,
   "SanctumFloor": {
     "className": "Part",

--- a/Assets/Maps/DesertOutpost.model.json
+++ b/Assets/Maps/DesertOutpost.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "DesertOutpost",
   "NeedsPivotMigration": false,
   "SandFloor": {
     "className": "Part",

--- a/Assets/Maps/FrozenTundra.model.json
+++ b/Assets/Maps/FrozenTundra.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "FrozenTundra",
   "NeedsPivotMigration": false,
   "SnowField": {
     "className": "Part",

--- a/Assets/Maps/LegendaryForge.model.json
+++ b/Assets/Maps/LegendaryForge.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "LegendaryForge",
   "NeedsPivotMigration": false,
   "MountainBase": {
     "className": "Part",

--- a/Assets/Maps/RoyalCastle.model.json
+++ b/Assets/Maps/RoyalCastle.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "RoyalCastle",
   "NeedsPivotMigration": false,
   "CastleGround": {
     "className": "Part",

--- a/Assets/Maps/ShadowDragonLair.model.json
+++ b/Assets/Maps/ShadowDragonLair.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "ShadowDragonLair",
   "NeedsPivotMigration": false,
   "LairCavern": {
     "className": "Part",

--- a/Assets/Maps/SiegedCity.model.json
+++ b/Assets/Maps/SiegedCity.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "SiegedCity",
   "NeedsPivotMigration": false,
   "CityGround": {
     "className": "Part",

--- a/Assets/Maps/SkyTower.model.json
+++ b/Assets/Maps/SkyTower.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "SkyTower",
   "NeedsPivotMigration": false,
   "BasePlatform": {
     "className": "Part",

--- a/Assets/Maps/StarterVillage.model.json
+++ b/Assets/Maps/StarterVillage.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "StarterVillage",
   "NeedsPivotMigration": false,
   "Ground": {
     "className": "Part",

--- a/Assets/Maps/VolcanicCrater.model.json
+++ b/Assets/Maps/VolcanicCrater.model.json
@@ -1,5 +1,6 @@
 {
   "className": "Model",
+  "Name": "VolcanicCrater",
   "NeedsPivotMigration": false,
   "CraterBase": {
     "className": "Part",

--- a/tests/server/MapManager.spec.lua
+++ b/tests/server/MapManager.spec.lua
@@ -30,6 +30,22 @@ return function()
     describe("MapManager", function()
         local player
 
+        it("exports map assets with pivot migration disabled", function()
+            local mapsFolder = MapManager:GetMapsFolder()
+
+            for _, config in pairs(MapConfig) do
+                if type(config) == "table" and type(config.assetName) == "string" then
+                    local asset = mapsFolder:FindFirstChild(config.assetName)
+                    expect(asset).to.be.ok()
+
+                    if asset:IsA("Model") then
+                        expect(asset.NeedsPivotMigration).to.equal(false)
+                        expect(asset.Name).to.equal(config.assetName)
+                    end
+                end
+            end
+        end)
+
         beforeEach(function()
             destroyMapInstances()
             MapManager:Unload()


### PR DESCRIPTION
## Summary
- add explicit `Name` metadata to every map model so Studio no longer re-flags pivot migration on sync
- add a regression test that asserts the exported map assets keep `NeedsPivotMigration` disabled and expose the expected names

## Testing
- not run (Roblox CLI/TestEZ runtime unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68caa45d71e4832f929dad72523c134b